### PR TITLE
Add Wealthsimple bank adapter scaffold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,18 +1309,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.31.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
@@ -3292,15 +3280,6 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -14,9 +14,11 @@ interface Window {
 }
 
 type Account = {
+  key?: string;
   name: string;
   balance: string;
 };
+type TransactionAccountType = 'credit_card' | 'checking' | 'savings' | 'unknown';
 type Transaction = {
   key: string;
   date: string;
@@ -28,6 +30,7 @@ type Transaction = {
   maskedCardNumber: string;
   cardLastFour: string;
   accountName: string;
+  accountType: TransactionAccountType;
   direction: 'credit' | 'debit' | 'unknown';
   category: string;
 };
@@ -69,6 +72,7 @@ type ExtensionSettings = {
   balanceDatabase: Database | null;
   transactionsDatabase: Database | null;
   transactionsFieldMapping: TransactionsFieldMapping | null;
+  invertTransactionSigns: boolean;
   balanceDatabaseLinkDraft: string;
   transactionsDatabaseLinkDraft: string;
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -19,11 +19,14 @@ type Account = {
   balance: string;
 };
 type TransactionAccountType = 'credit_card' | 'checking' | 'savings' | 'unknown';
+type TransactionType = 'credit' | 'debit';
 type Transaction = {
   key: string;
   date: string;
   amountText: string;
   amountValue: number;
+  rawAmountValue: number;
+  currencyCode: string | null;
   cardProductName: string;
   merchant: string;
   description: string;
@@ -31,7 +34,7 @@ type Transaction = {
   cardLastFour: string;
   accountName: string;
   accountType: TransactionAccountType;
-  direction: 'credit' | 'debit' | 'unknown';
+  type: TransactionType;
   category: string;
 };
 
@@ -64,6 +67,7 @@ type TransactionsFieldMapping = {
   amountProperty: string;
   merchantProperty: string;
   accountNameProperty: string;
+  typeProperty: string;
 };
 type ExtensionSettings = {
   availableAccounts: Record<string, string>;
@@ -72,7 +76,6 @@ type ExtensionSettings = {
   balanceDatabase: Database | null;
   transactionsDatabase: Database | null;
   transactionsFieldMapping: TransactionsFieldMapping | null;
-  invertTransactionSigns: boolean;
   balanceDatabaseLinkDraft: string;
   transactionsDatabaseLinkDraft: string;
 };

--- a/src/lib/bank/cibc.ts
+++ b/src/lib/bank/cibc.ts
@@ -107,6 +107,7 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
         maskedCardNumber,
         cardLastFour,
         accountName,
+        accountType: 'credit_card',
         direction,
         category,
       };

--- a/src/lib/bank/cibc.ts
+++ b/src/lib/bank/cibc.ts
@@ -113,27 +113,7 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
       };
     });
 
-  const initialTransactions = readTransactions();
-  if (initialTransactions.length > 0) {
-    return Promise.resolve(initialTransactions);
-  }
-
-  return new Promise<Transaction[]>((resolve) => {
-    const startedAt = Date.now();
-    const intervalId = window.setInterval(() => {
-      const transactions = readTransactions();
-      if (transactions.length > 0) {
-        window.clearInterval(intervalId);
-        resolve(transactions);
-        return;
-      }
-
-      if (Date.now() - startedAt >= 4000) {
-        window.clearInterval(intervalId);
-        resolve([]);
-      }
-    }, 200);
-  });
+  return readTransactions();
 };
 
 export const CIBC_BANK_ADAPTER: BankAdapter = {

--- a/src/lib/bank/cibc.ts
+++ b/src/lib/bank/cibc.ts
@@ -59,6 +59,21 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
     const parsed = parseFloat(normalized.replace(/[^0-9.-]+/g, ''));
     return Number.isNaN(parsed) ? 0 : parsed;
   };
+  const getCurrencyCode = (value: string): string | null => {
+    const currencyMatch = value.match(/\b([A-Z]{3})\b/);
+    return currencyMatch?.[1] ?? null;
+  };
+  const inferTransactionType = (amountClassList: string[], rawAmountValue: number): TransactionType => {
+    if (amountClassList.includes('credit')) {
+      return 'credit';
+    }
+
+    if (amountClassList.includes('debit')) {
+      return 'debit';
+    }
+
+    return rawAmountValue < 0 ? 'debit' : 'credit';
+  };
 
   const parseTransactionDate = (value: string): string => {
     const parsed = new Date(value);
@@ -91,8 +106,8 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
       const categoryIcon = row.querySelector('td.transactions img[title]') as HTMLImageElement | null;
       const category = categoryIcon?.title?.trim() ?? '';
       const cardLastFour = (maskedCardNumber.match(/(\d{4})$/) ?? [])[1] ?? '';
-      const amountValue = parseSignedAmount(amountText);
-      const direction = amountClassList.includes('credit') ? 'credit' : amountClassList.includes('debit') ? 'debit' : 'unknown';
+      const rawAmountValue = parseSignedAmount(amountText);
+      const type = inferTransactionType(amountClassList, rawAmountValue);
       const accountName =
         cardProductName && cardLastFour ? `${cardProductName} ${cardLastFour}` : cardLastFour ? `Card ${cardLastFour}` : cardProductName || 'Card';
 
@@ -100,7 +115,9 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
         key: `${dateText}-${amountText}-${description}-${maskedCardNumber}`,
         date: parseTransactionDate(dateText),
         amountText,
-        amountValue: Number.isNaN(amountValue) ? 0 : amountValue,
+        amountValue: Math.abs(Number.isNaN(rawAmountValue) ? 0 : rawAmountValue),
+        rawAmountValue: Number.isNaN(rawAmountValue) ? 0 : rawAmountValue,
+        currencyCode: getCurrencyCode(amountText),
         cardProductName,
         merchant: description,
         description,
@@ -108,7 +125,7 @@ const cibcExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
         cardLastFour,
         accountName,
         accountType: 'credit_card',
-        direction,
+        type,
         category,
       };
     });

--- a/src/lib/bank/index.ts
+++ b/src/lib/bank/index.ts
@@ -1,7 +1,8 @@
 import { CIBC_BANK_ADAPTER } from './cibc';
+import { WEALTHSIMPLE_BANK_ADAPTER } from './wealthsimple';
 import { BankAdapter, BankId } from './type';
 
-export const BANK_ADAPTERS: BankAdapter[] = [CIBC_BANK_ADAPTER];
+export const BANK_ADAPTERS: BankAdapter[] = [CIBC_BANK_ADAPTER, WEALTHSIMPLE_BANK_ADAPTER];
 
 export const detectBankFromHost = (hostname: string): BankAdapter | null =>
   BANK_ADAPTERS.find((adapter) => adapter.domainHosts.some((host) => hostname === host || hostname.endsWith(`.${host}`))) ?? null;

--- a/src/lib/bank/wealthsimple.ts
+++ b/src/lib/bank/wealthsimple.ts
@@ -450,27 +450,7 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
     return transactions;
   };
 
-  const initialTransactions = readTransactions();
-  if (initialTransactions.length > 0) {
-    return Promise.resolve(initialTransactions);
-  }
-
-  return new Promise<Transaction[]>((resolve) => {
-    const startedAt = Date.now();
-    const intervalId = window.setInterval(() => {
-      const transactions = readTransactions();
-      if (transactions.length > 0) {
-        window.clearInterval(intervalId);
-        resolve(transactions);
-        return;
-      }
-
-      if (Date.now() - startedAt >= 4000) {
-        window.clearInterval(intervalId);
-        resolve([]);
-      }
-    }, 200);
-  });
+  return readTransactions();
 };
 
 export const WEALTHSIMPLE_BANK_ADAPTER: BankAdapter = {

--- a/src/lib/bank/wealthsimple.ts
+++ b/src/lib/bank/wealthsimple.ts
@@ -1,0 +1,318 @@
+import { AccountGroupMap, BankAdapter, BankPageMode, InjectedPageFn } from './type';
+
+const wealthsimpleDetectPageMode: InjectedPageFn<[], BankPageMode> = () => {
+  const pathname = window.location.pathname.toLowerCase();
+  const pageText = document.body?.innerText?.replace(/\s+/g, ' ').toLowerCase() ?? '';
+
+  const hasMatchingElement = (selectors: string[]) => selectors.some((selector) => Boolean(document.querySelector(selector)));
+  const isWealthsimpleAccountLabel = (text: string) =>
+    text === 'Chequing' || text.startsWith('Credit card • ') || text.startsWith('Joint chequing • ');
+  const hasWealthsimpleCreditCardTransactions = () =>
+    Array.from(document.querySelectorAll('button[aria-controls][id$="-header"]')).some((button) => {
+      if (!(button instanceof HTMLElement)) {
+        return false;
+      }
+
+      const texts = Array.from(button.querySelectorAll('p'))
+        .map((element) => element.textContent?.replace(/\s+/g, ' ').trim() ?? '')
+        .filter(Boolean);
+
+      const hasAccountLabel = texts.some((text) => isWealthsimpleAccountLabel(text));
+      const hasAmount = texts.some((text) => /[-+−–]?\s*\$[\d,]+(?:\.\d{2})?\s*[A-Z]{3}/.test(text));
+
+      return hasAccountLabel && hasAmount;
+    });
+
+  const transactionSelectors = [
+    '[data-testid*="activity"]',
+    '[data-testid*="transaction"]',
+    '[aria-label*="activity" i]',
+    '[aria-label*="transaction" i]',
+    '[role="table"]',
+    'table',
+  ];
+
+  const balanceSelectors = [
+    '[data-testid*="account"]',
+    '[data-testid*="holding"]',
+    '[data-testid*="portfolio"]',
+    '[aria-label*="account" i]',
+    '[aria-label*="holding" i]',
+    '[role="table"]',
+    'table',
+  ];
+
+  if (
+    hasWealthsimpleCreditCardTransactions() ||
+    ((pathname.includes('/activity') ||
+      pathname.includes('/transactions') ||
+      pageText.includes('recent activity') ||
+      pageText.includes('transaction history')) &&
+      hasMatchingElement(transactionSelectors))
+  ) {
+    return 'transactions';
+  }
+
+  if (
+    (pathname.includes('/accounts') ||
+      pathname.includes('/portfolio') ||
+      pathname.includes('/invest') ||
+      pageText.includes('net worth') ||
+      pageText.includes('holdings')) &&
+    hasMatchingElement(balanceSelectors)
+  ) {
+    return 'balances';
+  }
+
+  return 'unknown';
+};
+
+const wealthsimpleExtractAccountGroups: InjectedPageFn<[], AccountGroupMap> = () => {
+  const containers = document.querySelectorAll(
+    '[data-testid*="account"], [data-testid*="holding"], [data-testid*="portfolio"], [role="table"], table',
+  );
+
+  if (containers.length === 0) {
+    return {} as AccountGroupMap;
+  }
+
+  return {
+    all: 'All Wealthsimple accounts',
+  };
+};
+
+const wealthsimpleExtractAccounts: InjectedPageFn<[selectedGroupKeys: string[]], Account[]> = (selectedGroupKeys) => {
+  const shouldReadAll = selectedGroupKeys.length === 0 || selectedGroupKeys.includes('all');
+  if (!shouldReadAll) {
+    return [];
+  }
+
+  const containers = Array.from(
+    document.querySelectorAll(
+      '[data-testid*="account"], [data-testid*="holding"], [data-testid*="portfolio"], [role="table"], table',
+    ),
+  );
+  const seen = new Set<string>();
+  const accounts: Account[] = [];
+
+  containers.forEach((container, index) => {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+
+    const lines = container.innerText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    if (lines.length === 0) {
+      return;
+    }
+
+    const balance = lines.find((line) => /[-+−–]?\$[\d,]+(?:\.\d{2})?/.test(line)) ?? '';
+    const name = lines.find((line) => line !== balance) ?? `Wealthsimple account ${index + 1}`;
+    const dedupeKey = `${name}|${balance}`;
+
+    if (seen.has(dedupeKey)) {
+      return;
+    }
+
+    seen.add(dedupeKey);
+    accounts.push({
+      name,
+      balance,
+    });
+  });
+
+  return accounts;
+};
+
+const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
+  const isWealthsimpleAccountLabel = (text: string) =>
+    text === 'Chequing' || text.startsWith('Credit card • ') || text.startsWith('Joint chequing • ');
+
+  const parseSignedAmount = (value: string): number => {
+    const normalized = value.replace(/[−–]/g, '-');
+    const parsed = parseFloat(normalized.replace(/[^0-9.-]+/g, ''));
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  const parseTransactionDate = (value: string): string => {
+    const normalizedValue = value.trim().toLowerCase();
+
+    if (normalizedValue === 'today' || normalizedValue === 'yesterday') {
+      const relativeDate = new Date();
+      if (normalizedValue === 'yesterday') {
+        relativeDate.setDate(relativeDate.getDate() - 1);
+      }
+
+      const year = relativeDate.getFullYear();
+      const month = `${relativeDate.getMonth() + 1}`.padStart(2, '0');
+      const day = `${relativeDate.getDate()}`.padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return value;
+    }
+
+    const year = parsed.getFullYear();
+    const month = `${parsed.getMonth() + 1}`.padStart(2, '0');
+    const day = `${parsed.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  const isSupportedDateHeadingText = (value: string): boolean => {
+    const normalizedValue = value.trim().toLowerCase();
+    if (!normalizedValue) {
+      return false;
+    }
+
+    if (normalizedValue === 'today' || normalizedValue === 'yesterday') {
+      return true;
+    }
+
+    return !Number.isNaN(new Date(value).getTime());
+  };
+
+  const isDateHeading = (element: Element): element is HTMLHeadingElement => {
+    if (!(element instanceof HTMLHeadingElement)) {
+      return false;
+    }
+
+    const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    return isSupportedDateHeadingText(text);
+  };
+
+  const isTransactionButton = (element: Element): element is HTMLButtonElement => {
+    if (!(element instanceof HTMLButtonElement)) {
+      return false;
+    }
+
+    const texts = Array.from(element.querySelectorAll('p'))
+      .map((paragraph) => paragraph.textContent?.replace(/\s+/g, ' ').trim() ?? '')
+      .filter(Boolean);
+
+    const hasAccountLabel = texts.some((text) => isWealthsimpleAccountLabel(text));
+    const hasAmount = texts.some((text) => /[-+−–]?\s*\$[\d,]+(?:\.\d{2})?\s*[A-Z]{3}/.test(text));
+
+    return hasAccountLabel && hasAmount;
+  };
+
+  const getTimelineElements = () =>
+    Array.from(document.querySelectorAll('h2, button[aria-controls][id$="-header"]')).filter((element) => {
+      if (isDateHeading(element)) {
+        return true;
+      }
+
+      return isTransactionButton(element);
+    });
+
+  const findNearestDateHeadingText = (button: HTMLButtonElement): string => {
+    let currentElement: Element | null = button;
+
+    while (currentElement) {
+      let sibling: Element | null = currentElement.previousElementSibling;
+      while (sibling) {
+        const directHeading = sibling.matches('h2') ? sibling : sibling.querySelector('h2');
+        if (directHeading instanceof HTMLHeadingElement) {
+          const headingText = directHeading.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+          if (isSupportedDateHeadingText(headingText)) {
+            return headingText;
+          }
+        }
+
+        sibling = sibling.previousElementSibling;
+      }
+
+      currentElement = currentElement.parentElement;
+    }
+
+    return '';
+  };
+
+  const readTransactions = (): Transaction[] => {
+    const timelineElements = getTimelineElements();
+    const transactions: Transaction[] = [];
+    let currentDateText = '';
+
+    timelineElements.forEach((element, index) => {
+      if (isDateHeading(element)) {
+        currentDateText = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+        return;
+      }
+
+      if (!isTransactionButton(element)) {
+        return;
+      }
+
+      const texts = Array.from(element.querySelectorAll('p'))
+        .map((paragraph) => paragraph.textContent?.replace(/\s+/g, ' ').trim() ?? '')
+        .filter(Boolean);
+
+      const amountText = texts.find((text) => /[-+−–]?\s*\$[\d,]+(?:\.\d{2})?\s*[A-Z]{3}/.test(text)) ?? '';
+      const accountLabel = texts.find((text) => isWealthsimpleAccountLabel(text)) ?? 'Wealthsimple account';
+      const contentTexts = texts.filter((text) => text !== amountText && text !== accountLabel);
+      const merchant = contentTexts[0] ?? `Transaction ${index + 1}`;
+      const detail = contentTexts[1] ?? '';
+      const accountName = accountLabel.includes('•') ? accountLabel.split('•').pop()?.trim() ?? accountLabel : accountLabel;
+      const amountValue = parseSignedAmount(amountText);
+      const direction = amountValue < 0 ? 'debit' : amountValue > 0 ? 'credit' : 'unknown';
+      const dateText = currentDateText || findNearestDateHeadingText(element);
+
+      transactions.push({
+        key: `${dateText}-${amountText}-${detail || merchant}-${index}`,
+        date: parseTransactionDate(dateText),
+        amountText,
+        amountValue,
+        cardProductName: accountName,
+        merchant,
+        description: detail || merchant,
+        maskedCardNumber: '',
+        cardLastFour: '',
+        accountName,
+        direction,
+        category: detail,
+      });
+    });
+
+    return transactions;
+  };
+
+  const initialTransactions = readTransactions();
+  if (initialTransactions.length > 0) {
+    return Promise.resolve(initialTransactions);
+  }
+
+  return new Promise<Transaction[]>((resolve) => {
+    const startedAt = Date.now();
+    const intervalId = window.setInterval(() => {
+      const transactions = readTransactions();
+      if (transactions.length > 0) {
+        window.clearInterval(intervalId);
+        resolve(transactions);
+        return;
+      }
+
+      if (Date.now() - startedAt >= 4000) {
+        window.clearInterval(intervalId);
+        resolve([]);
+      }
+    }, 200);
+  });
+};
+
+export const WEALTHSIMPLE_BANK_ADAPTER: BankAdapter = {
+  id: 'ws',
+  name: 'Wealthsimple',
+  domainHosts: ['app.wealthsimple.com', 'my.wealthsimple.com'],
+  capabilities: {
+    balances: true,
+    transactions: true,
+  },
+  detectPageMode: wealthsimpleDetectPageMode,
+  extractAccountGroups: wealthsimpleExtractAccountGroups,
+  extractAccounts: wealthsimpleExtractAccounts,
+  extractTransactions: wealthsimpleExtractTransactions,
+};

--- a/src/lib/bank/wealthsimple.ts
+++ b/src/lib/bank/wealthsimple.ts
@@ -7,6 +7,69 @@ const wealthsimpleDetectPageMode: InjectedPageFn<[], BankPageMode> = () => {
   const hasMatchingElement = (selectors: string[]) => selectors.some((selector) => Boolean(document.querySelector(selector)));
   const isWealthsimpleAccountLabel = (text: string) =>
     text === 'Chequing' || text.startsWith('Credit card • ') || text.startsWith('Joint chequing • ');
+  const hasWealthsimpleHomeAccounts = () =>
+    Array.from(document.querySelectorAll('a[href^="/app/account-details/"]')).some((link) => {
+      if (!(link instanceof HTMLAnchorElement)) {
+        return false;
+      }
+
+      const labelledBy = link.getAttribute('aria-labelledby');
+      const contentRoot = labelledBy ? document.getElementById(labelledBy) ?? link : link;
+      const text = contentRoot.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+      return Boolean(text) && /\$[\d,]+(?:\.\d{2})?/.test(text);
+    });
+  const hasWealthsimpleBalanceAccounts = () => {
+    const isCurrencyLine = (text: string) => /[-+−–]?\s*\$[\d,]+(?:\.\d{2})?(?:\s*[A-Z]{3})?/.test(text);
+    const isNoiseLine = (text: string) => {
+      const normalized = text.toLowerCase();
+      return (
+        normalized === 'today' ||
+        normalized === 'yesterday' ||
+        normalized.includes('recent activity') ||
+        normalized.includes('transaction history') ||
+        normalized.includes('purchase') ||
+        normalized.includes('direct deposit') ||
+        normalized.includes('interac e-transfer') ||
+        normalized.includes('pre-authorized debit') ||
+        normalized.includes('transfer out')
+      );
+    };
+    const isLikelyAccountLabel = (text: string) => {
+      const normalized = text.toLowerCase();
+      return (
+        normalized === 'chequing' ||
+        normalized.startsWith('joint chequing') ||
+        normalized.includes('credit card') ||
+        normalized.includes('cash') ||
+        normalized.includes('tfsa') ||
+        normalized.includes('rrsp') ||
+        normalized.includes('fhsa') ||
+        normalized.includes('resp') ||
+        normalized.includes('invest') ||
+        normalized.includes('save')
+      );
+    };
+
+    return Array.from(
+      document.querySelectorAll(
+        'button, a, [role="button"], [data-testid*="account"], [data-testid*="holding"], [data-testid*="portfolio"], [data-testid*="product"]',
+      ),
+    ).some((element) => {
+      if (!(element instanceof HTMLElement)) {
+        return false;
+      }
+
+      const lines = element.innerText
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      const amount = lines.find(isCurrencyLine);
+      const label = lines.find((line) => isLikelyAccountLabel(line) && !isNoiseLine(line));
+
+      return Boolean(amount && label);
+    });
+  };
   const hasWealthsimpleCreditCardTransactions = () =>
     Array.from(document.querySelectorAll('button[aria-controls][id$="-header"]')).some((button) => {
       if (!(button instanceof HTMLElement)) {
@@ -54,12 +117,15 @@ const wealthsimpleDetectPageMode: InjectedPageFn<[], BankPageMode> = () => {
   }
 
   if (
-    (pathname.includes('/accounts') ||
+    (hasWealthsimpleHomeAccounts() ||
+      hasWealthsimpleBalanceAccounts() ||
+      pathname.includes('/app/home') ||
+      pathname.includes('/accounts') ||
       pathname.includes('/portfolio') ||
       pathname.includes('/invest') ||
       pageText.includes('net worth') ||
       pageText.includes('holdings')) &&
-    hasMatchingElement(balanceSelectors)
+    (hasWealthsimpleHomeAccounts() || hasMatchingElement(balanceSelectors))
   ) {
     return 'balances';
   }
@@ -68,9 +134,17 @@ const wealthsimpleDetectPageMode: InjectedPageFn<[], BankPageMode> = () => {
 };
 
 const wealthsimpleExtractAccountGroups: InjectedPageFn<[], AccountGroupMap> = () => {
-  const containers = document.querySelectorAll(
-    '[data-testid*="account"], [data-testid*="holding"], [data-testid*="portfolio"], [role="table"], table',
-  );
+  const accountLinks = Array.from(document.querySelectorAll('a[href^="/app/account-details/"]'));
+  const containers = accountLinks.filter((element) => {
+    if (!(element instanceof HTMLAnchorElement)) {
+      return false;
+    }
+
+    const labelledBy = element.getAttribute('aria-labelledby');
+    const contentRoot = labelledBy ? document.getElementById(labelledBy) ?? element : element;
+    const text = contentRoot.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+    return Boolean(text) && /\$[\d,]+(?:\.\d{2})?/.test(text);
+  });
 
   if (containers.length === 0) {
     return {} as AccountGroupMap;
@@ -87,31 +161,104 @@ const wealthsimpleExtractAccounts: InjectedPageFn<[selectedGroupKeys: string[]],
     return [];
   }
 
-  const containers = Array.from(
-    document.querySelectorAll(
-      '[data-testid*="account"], [data-testid*="holding"], [data-testid*="portfolio"], [role="table"], table',
-    ),
-  );
+  const isCurrencyLine = (text: string) => /[-+−–]?\s*\$[\d,]+(?:\.\d{2})?(?:\s*[A-Z]{3})?/.test(text);
+  const isPerformanceLine = (text: string) => /(?:all time|today|this month|this year|action required|bi-weekly)/i.test(text);
+  const isCountLine = (text: string) => /^\d+\s+accounts?$/i.test(text);
+  const isStatusLine = (text: string) =>
+    /^(managed|alt investments|crypto|action required)$/i.test(text.trim());
+  const isNoiseLine = (text: string) => {
+    const normalized = text.toLowerCase();
+    return (
+      normalized === 'today' ||
+      normalized === 'yesterday' ||
+      normalized.includes('recent activity') ||
+      normalized.includes('transaction history') ||
+      isCountLine(text) ||
+      isPerformanceLine(text) ||
+      isStatusLine(text)
+    );
+  };
+  const getElementLines = (element: Element | null): string[] => {
+    if (!(element instanceof HTMLElement)) {
+      return [];
+    }
+
+    return element.innerText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  };
+  const getGroupTitle = (link: HTMLAnchorElement): string => {
+    const region = link.closest('[role="region"]');
+    if (!(region instanceof HTMLElement)) {
+      return '';
+    }
+
+    const labelledBy = region.getAttribute('aria-labelledby');
+    if (!labelledBy) {
+      return '';
+    }
+
+    const header = document.getElementById(labelledBy);
+    const headerLines = getElementLines(header);
+    return headerLines.find((line) => !isNoiseLine(line) && !isCurrencyLine(line)) ?? '';
+  };
+  const buildAccountName = (primaryName: string, secondaryName: string, groupTitle: string): string => {
+    const normalizedPrimary = primaryName.toLowerCase();
+    const normalizedSecondary = secondaryName.toLowerCase();
+    const normalizedGroup = groupTitle.toLowerCase();
+
+    if (
+      secondaryName &&
+      normalizedSecondary !== normalizedPrimary &&
+      !isNoiseLine(secondaryName) &&
+      !isCurrencyLine(secondaryName)
+    ) {
+      return `${primaryName} • ${secondaryName}`;
+    }
+
+    if (
+      groupTitle &&
+      normalizedGroup !== normalizedPrimary &&
+      !normalizedPrimary.includes(normalizedGroup) &&
+      !isNoiseLine(groupTitle)
+    ) {
+      return `${groupTitle} • ${primaryName}`;
+    }
+
+    return primaryName;
+  };
+
+  const containers = Array.from(document.querySelectorAll('a[href^="/app/account-details/"]'));
   const seen = new Set<string>();
   const accounts: Account[] = [];
 
   containers.forEach((container, index) => {
-    if (!(container instanceof HTMLElement)) {
+    if (!(container instanceof HTMLAnchorElement)) {
       return;
     }
 
-    const lines = container.innerText
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
+    const labelledBy = container.getAttribute('aria-labelledby');
+    const contentRoot = labelledBy ? document.getElementById(labelledBy) ?? container : container;
+    const lines = getElementLines(contentRoot);
 
     if (lines.length === 0) {
       return;
     }
 
-    const balance = lines.find((line) => /[-+−–]?\$[\d,]+(?:\.\d{2})?/.test(line)) ?? '';
-    const name = lines.find((line) => line !== balance) ?? `Wealthsimple account ${index + 1}`;
-    const dedupeKey = `${name}|${balance}`;
+    const balance = lines.find(isCurrencyLine) ?? '';
+    const contentLines = lines.filter((line) => line !== balance && !isNoiseLine(line) && !isCurrencyLine(line));
+    const primaryName = contentLines[0] ?? `Wealthsimple account ${index + 1}`;
+    const secondaryName = contentLines[1] ?? '';
+    const groupTitle = getGroupTitle(container);
+    const name = buildAccountName(primaryName, secondaryName, groupTitle);
+    const key = container.getAttribute('href') ?? `${name}-${index}`;
+
+    if (!balance || !name || isNoiseLine(name)) {
+      return;
+    }
+
+    const dedupeKey = key;
 
     if (seen.has(dedupeKey)) {
       return;
@@ -119,6 +266,7 @@ const wealthsimpleExtractAccounts: InjectedPageFn<[selectedGroupKeys: string[]],
 
     seen.add(dedupeKey);
     accounts.push({
+      key,
       name,
       balance,
     });
@@ -129,7 +277,27 @@ const wealthsimpleExtractAccounts: InjectedPageFn<[selectedGroupKeys: string[]],
 
 const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () => {
   const isWealthsimpleAccountLabel = (text: string) =>
-    text === 'Chequing' || text.startsWith('Credit card • ') || text.startsWith('Joint chequing • ');
+    text === 'Chequing' ||
+    text.startsWith('Credit card • ') ||
+    text.startsWith('Joint chequing • ') ||
+    /saving|save/i.test(text);
+  const inferAccountType = (accountLabel: string): TransactionAccountType => {
+    const normalized = accountLabel.trim().toLowerCase();
+
+    if (normalized.startsWith('credit card')) {
+      return 'credit_card';
+    }
+
+    if (normalized === 'chequing' || normalized.startsWith('joint chequing')) {
+      return 'checking';
+    }
+
+    if (normalized.includes('saving') || normalized.includes('save')) {
+      return 'savings';
+    }
+
+    return 'unknown';
+  };
 
   const parseSignedAmount = (value: string): number => {
     const normalized = value.replace(/[−–]/g, '-');
@@ -257,6 +425,7 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
       const merchant = contentTexts[0] ?? `Transaction ${index + 1}`;
       const detail = contentTexts[1] ?? '';
       const accountName = accountLabel.includes('•') ? accountLabel.split('•').pop()?.trim() ?? accountLabel : accountLabel;
+      const accountType = inferAccountType(accountLabel);
       const amountValue = parseSignedAmount(amountText);
       const direction = amountValue < 0 ? 'debit' : amountValue > 0 ? 'credit' : 'unknown';
       const dateText = currentDateText || findNearestDateHeadingText(element);
@@ -272,6 +441,7 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
         maskedCardNumber: '',
         cardLastFour: '',
         accountName,
+        accountType,
         direction,
         category: detail,
       });

--- a/src/lib/bank/wealthsimple.ts
+++ b/src/lib/bank/wealthsimple.ts
@@ -298,11 +298,16 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
 
     return 'unknown';
   };
+  const inferTransactionType = (rawAmountValue: number): TransactionType => (rawAmountValue < 0 ? 'debit' : 'credit');
 
   const parseSignedAmount = (value: string): number => {
     const normalized = value.replace(/[−–]/g, '-');
     const parsed = parseFloat(normalized.replace(/[^0-9.-]+/g, ''));
     return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  const getCurrencyCode = (value: string): string | null => {
+    const currencyMatch = value.match(/\b([A-Z]{3})\b/);
+    return currencyMatch?.[1] ?? null;
   };
 
   const parseTransactionDate = (value: string): string => {
@@ -426,15 +431,16 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
       const detail = contentTexts[1] ?? '';
       const accountName = accountLabel.includes('•') ? accountLabel.split('•').pop()?.trim() ?? accountLabel : accountLabel;
       const accountType = inferAccountType(accountLabel);
-      const amountValue = parseSignedAmount(amountText);
-      const direction = amountValue < 0 ? 'debit' : amountValue > 0 ? 'credit' : 'unknown';
+      const rawAmountValue = parseSignedAmount(amountText);
       const dateText = currentDateText || findNearestDateHeadingText(element);
 
       transactions.push({
         key: `${dateText}-${amountText}-${detail || merchant}-${index}`,
         date: parseTransactionDate(dateText),
         amountText,
-        amountValue,
+        amountValue: Math.abs(rawAmountValue),
+        rawAmountValue,
+        currencyCode: getCurrencyCode(amountText),
         cardProductName: accountName,
         merchant,
         description: detail || merchant,
@@ -442,7 +448,7 @@ const wealthsimpleExtractTransactions: InjectedPageFn<[], Transaction[]> = () =>
         cardLastFour: '',
         accountName,
         accountType,
-        direction,
+        type: inferTransactionType(rawAmountValue),
         category: detail,
       });
     });

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -260,22 +260,21 @@ const findPropertyByType = (database: Database, type: string): DatabaseProperty 
 export const suggestTransactionsFieldMapping = (database: Database): TransactionsFieldMapping | null => {
   const titleProperty = database.properties.find((property) => property.type === 'title');
   const richTextProperties = database.properties.filter((property) => property.type === 'rich_text');
+  const nonSystemRichTextProperties = richTextProperties.filter(
+    (property) => property.name !== 'Account Name' && property.name !== 'Type' && property.name !== TRANSACTION_SYNC_ID_PROPERTY,
+  );
   const amountProperty = findPropertyByName(database, 'Amount') ?? findPropertyByType(database, 'number');
   const dateProperty = findPropertyByName(database, 'Date') ?? findPropertyByType(database, 'date');
   const merchantProperty =
     titleProperty ??
     findPropertyByName(database, 'Merchant') ??
+    findPropertyByName(database, 'Merchant/Description') ??
     findPropertyByName(database, 'Description') ??
-    richTextProperties[0];
+    nonSystemRichTextProperties[0];
   const accountNameProperty =
     findPropertyByName(database, 'Account Name') ??
-    richTextProperties.find((property) => property.name !== merchantProperty?.name);
-  const typeProperty =
-    findPropertyByName(database, 'Type') ??
-    findPropertyByType(database, 'select') ??
-    richTextProperties.find(
-      (property) => property.name !== merchantProperty?.name && property.name !== accountNameProperty?.name,
-    );
+    nonSystemRichTextProperties.find((property) => property.name !== merchantProperty?.name);
+  const typeProperty = findPropertyByName(database, 'Type');
 
   if (!dateProperty || !amountProperty || !merchantProperty || !accountNameProperty || !typeProperty) {
     return null;

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -68,7 +68,7 @@ type DatabaseConnectionResult = {
 };
 
 const BALANCE_REQUIRED_FIELDS = ['Account Name', 'Balance', 'Date'] as const;
-const TRANSACTION_REQUIRED_FIELDS = ['Date', 'Amount', 'Merchant/Description', 'Account Name'] as const;
+const TRANSACTION_REQUIRED_FIELDS = ['Date', 'Amount', 'Merchant/Description', 'Account Name', 'Type'] as const;
 export const TRANSACTION_SYNC_ID_PROPERTY = 'Sync ID';
 
 const BALANCE_AUTO_PROPERTIES = {
@@ -76,10 +76,20 @@ const BALANCE_AUTO_PROPERTIES = {
   Date: { date: {} },
 } as const;
 
+const TRANSACTION_TYPE_SELECT_PROPERTY: NotionDataSourceUpdateProperties[string] = {
+  select: {
+    options: [
+      { name: 'debit', color: 'red' },
+      { name: 'credit', color: 'green' },
+    ],
+  },
+};
+
 const TRANSACTION_AUTO_PROPERTIES = {
   Amount: { number: { format: 'dollar' } },
   Date: { date: {} },
   'Account Name': { rich_text: {} },
+  Type: TRANSACTION_TYPE_SELECT_PROPERTY,
   [TRANSACTION_SYNC_ID_PROPERTY]: { rich_text: {} },
 } as const;
 
@@ -201,8 +211,12 @@ const missingTransactionsFields = (database: Database): string[] => {
   const missing: string[] = [];
   const titleProperties = database.properties.filter((property) => property.type === 'title');
   const richTextProperties = database.properties.filter((property) => property.type === 'rich_text');
+  const hasMerchantProperty = titleProperties.length > 0 || richTextProperties.length > 0;
+  const hasAccountNameProperty =
+    Boolean(findPropertyByName(database, 'Account Name')) || richTextProperties.length >= (titleProperties.length > 0 ? 1 : 2);
+  const hasTypeProperty = Boolean(findPropertyByName(database, 'Type')) || database.properties.some((property) => property.type === 'select');
 
-  if (titleProperties.length === 0 && richTextProperties.length === 0) {
+  if (!hasMerchantProperty) {
     missing.push('Merchant/Description');
   }
   if (!database.properties.some((property) => property.type === 'number')) {
@@ -211,11 +225,11 @@ const missingTransactionsFields = (database: Database): string[] => {
   if (!database.properties.some((property) => property.type === 'date')) {
     missing.push('Date');
   }
-  if (richTextProperties.length === 0 && titleProperties.length > 0) {
+  if (!hasAccountNameProperty) {
     missing.push('Account Name');
   }
-  if (titleProperties.length === 0 && richTextProperties.length < 2) {
-    missing.push('Account Name');
+  if (!hasTypeProperty) {
+    missing.push('Type');
   }
 
   return missing;
@@ -243,7 +257,7 @@ const findPropertyByName = (database: Database, name: string): DatabaseProperty 
 const findPropertyByType = (database: Database, type: string): DatabaseProperty | undefined =>
   getDatabaseProperty(database, (property) => property.type === type);
 
-const buildDefaultTransactionsFieldMapping = (database: Database): TransactionsFieldMapping | null => {
+export const suggestTransactionsFieldMapping = (database: Database): TransactionsFieldMapping | null => {
   const titleProperty = database.properties.find((property) => property.type === 'title');
   const richTextProperties = database.properties.filter((property) => property.type === 'rich_text');
   const amountProperty = findPropertyByName(database, 'Amount') ?? findPropertyByType(database, 'number');
@@ -256,8 +270,14 @@ const buildDefaultTransactionsFieldMapping = (database: Database): TransactionsF
   const accountNameProperty =
     findPropertyByName(database, 'Account Name') ??
     richTextProperties.find((property) => property.name !== merchantProperty?.name);
+  const typeProperty =
+    findPropertyByName(database, 'Type') ??
+    findPropertyByType(database, 'select') ??
+    richTextProperties.find(
+      (property) => property.name !== merchantProperty?.name && property.name !== accountNameProperty?.name,
+    );
 
-  if (!dateProperty || !amountProperty || !merchantProperty || !accountNameProperty) {
+  if (!dateProperty || !amountProperty || !merchantProperty || !accountNameProperty || !typeProperty) {
     return null;
   }
 
@@ -266,9 +286,10 @@ const buildDefaultTransactionsFieldMapping = (database: Database): TransactionsF
     amountProperty.name,
     merchantProperty.name,
     accountNameProperty.name,
+    typeProperty.name,
   ]);
 
-  if (uniqueProperties.size !== 4) {
+  if (uniqueProperties.size !== 5) {
     return null;
   }
 
@@ -277,6 +298,7 @@ const buildDefaultTransactionsFieldMapping = (database: Database): TransactionsF
     amountProperty: amountProperty.name,
     merchantProperty: merchantProperty.name,
     accountNameProperty: accountNameProperty.name,
+    typeProperty: typeProperty.name,
   };
 };
 
@@ -406,6 +428,14 @@ const ensureTransactionsSchema = async (
     propertiesToCreate['Account Name'] = TRANSACTION_AUTO_PROPERTIES['Account Name'];
     autoCreatedFields.push('Account Name');
   }
+  const typeProperty = findPropertyByName(mapped, 'Type');
+  if (!typeProperty) {
+    propertiesToCreate.Type = TRANSACTION_AUTO_PROPERTIES.Type;
+    autoCreatedFields.push('Type');
+  } else if (typeProperty.type === 'rich_text') {
+    propertiesToCreate.Type = TRANSACTION_AUTO_PROPERTIES.Type;
+    autoCreatedFields.push('Type (converted to select)');
+  }
   if (!findPropertyByName(mapped, TRANSACTION_SYNC_ID_PROPERTY)) {
     propertiesToCreate[TRANSACTION_SYNC_ID_PROPERTY] = TRANSACTION_AUTO_PROPERTIES[TRANSACTION_SYNC_ID_PROPERTY];
     autoCreatedFields.push(TRANSACTION_SYNC_ID_PROPERTY);
@@ -493,7 +523,7 @@ export const connectNotionDatabase = async (
 
   return {
     database,
-    suggestedMapping: kind === 'transactions' ? buildDefaultTransactionsFieldMapping(database) : null,
+    suggestedMapping: kind === 'transactions' ? suggestTransactionsFieldMapping(database) : null,
   };
 };
 
@@ -534,13 +564,21 @@ export const validateTransactionsFieldMapping = (
     ['amountProperty', ['number']],
     ['merchantProperty', ['title', 'rich_text']],
     ['accountNameProperty', ['rich_text']],
+    ['typeProperty', ['select']],
   ];
+  const fieldLabels: Record<keyof TransactionsFieldMapping, string> = {
+    dateProperty: 'Date field',
+    amountProperty: 'Amount field',
+    merchantProperty: 'Merchant/Description field',
+    accountNameProperty: 'Account Name field',
+    typeProperty: 'Type field',
+  };
   const errors: string[] = [];
 
   for (const [field, allowedTypes] of rules) {
     const propertyName = mapping[field];
     if (!propertyName) {
-      errors.push(`${field} is required.`);
+      errors.push(`${fieldLabels[field]} is required.`);
       continue;
     }
 

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -258,22 +258,10 @@ const findPropertyByType = (database: Database, type: string): DatabaseProperty 
   getDatabaseProperty(database, (property) => property.type === type);
 
 export const suggestTransactionsFieldMapping = (database: Database): TransactionsFieldMapping | null => {
-  const titleProperty = database.properties.find((property) => property.type === 'title');
-  const richTextProperties = database.properties.filter((property) => property.type === 'rich_text');
-  const nonSystemRichTextProperties = richTextProperties.filter(
-    (property) => property.name !== 'Account Name' && property.name !== 'Type' && property.name !== TRANSACTION_SYNC_ID_PROPERTY,
-  );
-  const amountProperty = findPropertyByName(database, 'Amount') ?? findPropertyByType(database, 'number');
-  const dateProperty = findPropertyByName(database, 'Date') ?? findPropertyByType(database, 'date');
-  const merchantProperty =
-    titleProperty ??
-    findPropertyByName(database, 'Merchant') ??
-    findPropertyByName(database, 'Merchant/Description') ??
-    findPropertyByName(database, 'Description') ??
-    nonSystemRichTextProperties[0];
-  const accountNameProperty =
-    findPropertyByName(database, 'Account Name') ??
-    nonSystemRichTextProperties.find((property) => property.name !== merchantProperty?.name);
+  const amountProperty = findPropertyByName(database, 'Amount');
+  const dateProperty = findPropertyByName(database, 'Date');
+  const merchantProperty = findPropertyByName(database, 'Merchant/Description');
+  const accountNameProperty = findPropertyByName(database, 'Account Name');
   const typeProperty = findPropertyByName(database, 'Type');
 
   if (!dateProperty || !amountProperty || !merchantProperty || !accountNameProperty || !typeProperty) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,6 +6,7 @@ const STORAGE_KEYS = [
   'balanceDatabase',
   'transactionsDatabase',
   'transactionsFieldMapping',
+  'invertTransactionSigns',
   'balanceDatabaseLinkDraft',
   'transactionsDatabaseLinkDraft',
 ] as const;
@@ -24,6 +25,31 @@ const badgeClassForType = (type: string): string => {
       return 'bg-gray-100 text-gray-800';
   }
 };
+
+const normalizeAvailableAccounts = (availableAccounts: unknown): Record<string, string> => {
+  if (!availableAccounts || typeof availableAccounts !== 'object' || Array.isArray(availableAccounts)) {
+    return {};
+  }
+
+  return Object.entries(availableAccounts).reduce<Record<string, string>>((result, [key, value]) => {
+    if (typeof key !== 'string' || typeof value !== 'string') {
+      return result;
+    }
+
+    result[key] = value;
+    return result;
+  }, {});
+};
+
+const normalizeSelectedAccounts = (selectedAccounts: unknown): string[] => {
+  if (!Array.isArray(selectedAccounts)) {
+    return [];
+  }
+
+  return Array.from(new Set(selectedAccounts.filter((value): value is string => typeof value === 'string')));
+};
+
+const normalizeBoolean = (value: unknown, fallback = false): boolean => (typeof value === 'boolean' ? value : fallback);
 
 const normalizeDatabaseProperties = (properties: unknown): DatabaseProperty[] => {
   if (Array.isArray(properties)) {
@@ -77,6 +103,7 @@ const EMPTY_SETTINGS: ExtensionSettings = {
   balanceDatabase: null,
   transactionsDatabase: null,
   transactionsFieldMapping: null,
+  invertTransactionSigns: false,
   balanceDatabaseLinkDraft: '',
   transactionsDatabaseLinkDraft: '',
 };
@@ -89,6 +116,8 @@ export const getExtensionSettings = async (): Promise<ExtensionSettings> => {
   const stored = (await chrome.storage.local.get([...STORAGE_KEYS])) as RawSettings;
   const legacyDatabase = stored.selectedDatabase ?? null;
   const balanceDatabase = normalizeDatabase(stored.balanceDatabase ?? legacyDatabase);
+  const availableAccounts = normalizeAvailableAccounts(stored.availableAccounts);
+  const selectedAccounts = normalizeSelectedAccounts(stored.selectedAccounts);
 
   if (legacyDatabase && !stored.balanceDatabase) {
     await chrome.storage.local.set({
@@ -98,12 +127,13 @@ export const getExtensionSettings = async (): Promise<ExtensionSettings> => {
   }
 
   return {
-    availableAccounts: stored.availableAccounts ?? EMPTY_SETTINGS.availableAccounts,
-    selectedAccounts: stored.selectedAccounts ?? EMPTY_SETTINGS.selectedAccounts,
+    availableAccounts,
+    selectedAccounts,
     notionApiKey: stored.notionApiKey ?? EMPTY_SETTINGS.notionApiKey,
     balanceDatabase,
     transactionsDatabase: normalizeDatabase(stored.transactionsDatabase ?? EMPTY_SETTINGS.transactionsDatabase),
     transactionsFieldMapping: stored.transactionsFieldMapping ?? EMPTY_SETTINGS.transactionsFieldMapping,
+    invertTransactionSigns: normalizeBoolean(stored.invertTransactionSigns, EMPTY_SETTINGS.invertTransactionSigns),
     balanceDatabaseLinkDraft: stored.balanceDatabaseLinkDraft ?? balanceDatabase?.link ?? EMPTY_SETTINGS.balanceDatabaseLinkDraft,
     transactionsDatabaseLinkDraft:
       stored.transactionsDatabaseLinkDraft ??

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,7 +6,6 @@ const STORAGE_KEYS = [
   'balanceDatabase',
   'transactionsDatabase',
   'transactionsFieldMapping',
-  'invertTransactionSigns',
   'balanceDatabaseLinkDraft',
   'transactionsDatabaseLinkDraft',
 ] as const;
@@ -49,7 +48,21 @@ const normalizeSelectedAccounts = (selectedAccounts: unknown): string[] => {
   return Array.from(new Set(selectedAccounts.filter((value): value is string => typeof value === 'string')));
 };
 
-const normalizeBoolean = (value: unknown, fallback = false): boolean => (typeof value === 'boolean' ? value : fallback);
+const normalizeTransactionsFieldMapping = (mapping: unknown): TransactionsFieldMapping | null => {
+  if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+    return null;
+  }
+
+  const candidate = mapping as Partial<TransactionsFieldMapping>;
+
+  return {
+    dateProperty: typeof candidate.dateProperty === 'string' ? candidate.dateProperty : '',
+    amountProperty: typeof candidate.amountProperty === 'string' ? candidate.amountProperty : '',
+    merchantProperty: typeof candidate.merchantProperty === 'string' ? candidate.merchantProperty : '',
+    accountNameProperty: typeof candidate.accountNameProperty === 'string' ? candidate.accountNameProperty : '',
+    typeProperty: typeof candidate.typeProperty === 'string' ? candidate.typeProperty : '',
+  };
+};
 
 const normalizeDatabaseProperties = (properties: unknown): DatabaseProperty[] => {
   if (Array.isArray(properties)) {
@@ -103,7 +116,6 @@ const EMPTY_SETTINGS: ExtensionSettings = {
   balanceDatabase: null,
   transactionsDatabase: null,
   transactionsFieldMapping: null,
-  invertTransactionSigns: false,
   balanceDatabaseLinkDraft: '',
   transactionsDatabaseLinkDraft: '',
 };
@@ -132,8 +144,7 @@ export const getExtensionSettings = async (): Promise<ExtensionSettings> => {
     notionApiKey: stored.notionApiKey ?? EMPTY_SETTINGS.notionApiKey,
     balanceDatabase,
     transactionsDatabase: normalizeDatabase(stored.transactionsDatabase ?? EMPTY_SETTINGS.transactionsDatabase),
-    transactionsFieldMapping: stored.transactionsFieldMapping ?? EMPTY_SETTINGS.transactionsFieldMapping,
-    invertTransactionSigns: normalizeBoolean(stored.invertTransactionSigns, EMPTY_SETTINGS.invertTransactionSigns),
+    transactionsFieldMapping: normalizeTransactionsFieldMapping(stored.transactionsFieldMapping) ?? EMPTY_SETTINGS.transactionsFieldMapping,
     balanceDatabaseLinkDraft: stored.balanceDatabaseLinkDraft ?? balanceDatabase?.link ?? EMPTY_SETTINGS.balanceDatabaseLinkDraft,
     transactionsDatabaseLinkDraft:
       stored.transactionsDatabaseLinkDraft ??

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -61,7 +61,7 @@
             <div class="mb-5">
               <h2 class="text-2xl font-semibold">Account Sync</h2>
               <p class="mt-1 max-w-3xl text-stone-500 dark:text-stone-300">
-                Configure the balance database and choose which account groups should appear in the existing balance sync flow.
+                Configure the balance database and choose which detected accounts should appear in the balance sync flow.
               </p>
             </div>
 
@@ -166,10 +166,10 @@
               <section class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
                 <div class="mb-4">
                   <h3 class="text-xl font-semibold dark:text-stone-500">Select Accounts</h3>
-                  <p class="mt-1 text-stone-500">Choose which account groups should appear in balance sync.</p>
+                  <p class="mt-1 text-stone-500">Choose which detected accounts should appear in balance sync. This stays in sync with the Popup.</p>
                 </div>
 
-                <ul class="overflow-hidden rounded-2xl border border-stone-200 bg-white text-sm">
+                <ul x-show="hasAvailableAccounts" class="overflow-hidden rounded-2xl border border-stone-200 bg-white text-sm">
                   <template x-for="(account, index) in availableAccounts" :key="account.className">
                     <li class="flex w-full border-b border-stone-200 px-4 last:border-b-0">
                       <div class="flex items-center py-3">
@@ -187,6 +187,10 @@
                     </li>
                   </template>
                 </ul>
+
+                <p x-show="noAvailableAccounts" class="rounded-2xl border border-dashed border-stone-300 bg-white px-4 py-3 text-sm text-stone-500">
+                  Open a supported bank balances page in the Popup first to detect accounts here.
+                </p>
               </section>
             </div>
             </div>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -208,7 +208,7 @@
             <section class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
               <div class="mb-4">
                 <h3 class="text-xl font-semibold dark:text-stone-500">Transactions Database</h3>
-                <p class="mt-1 text-stone-500">This database is separate from balance sync and stores credit card transaction rows.</p>
+                <p class="mt-1 text-stone-500">This database is separate from balance sync and stores normalized transaction rows.</p>
               </div>
 
               <label for="transactions-link" class="mb-2 block text-sm font-medium text-stone-700">Transactions Database Block Link</label>
@@ -348,6 +348,19 @@
                           >
                             <option value="">Select a rich_text field</option>
                             <template x-for="property in transactionsAccountNameOptions" :key="property.id">
+                              <option :value="property.name" :selected="property.selected" x-text="property.name"></option>
+                            </template>
+                          </select>
+                        </label>
+
+                        <label class="text-sm text-stone-700">
+                          <span class="mb-1 block font-medium">Type Field</span>
+                          <select
+                            @change="onTransactionsTypeChange"
+                            class="w-full rounded-xl border border-stone-300 bg-white px-3 py-2.5 text-sm outline-none transition focus:border-lime-700 focus:ring-2 focus:ring-lime-700/20"
+                          >
+                            <option value="">Select a select field</option>
+                            <template x-for="property in transactionsTypeOptions" :key="property.id">
                               <option :value="property.name" :selected="property.selected" x-text="property.name"></option>
                             </template>
                           </select>

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -74,6 +74,38 @@ Alpine.data('accountOptions', () => ({
   async init() {
     const settings = await getExtensionSettings();
 
+    this.applySettingsSnapshot(settings);
+    this.refreshTransactionsMappingState();
+    this.refreshSaveHint();
+
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+      if (areaName !== 'local') {
+        return;
+      }
+
+      if (
+        !changes.availableAccounts &&
+        !changes.selectedAccounts &&
+        !changes.notionApiKey &&
+        !changes.balanceDatabase &&
+        !changes.transactionsDatabase &&
+        !changes.transactionsFieldMapping &&
+        !changes.balanceDatabaseLinkDraft &&
+        !changes.transactionsDatabaseLinkDraft
+      ) {
+        return;
+      }
+
+      getExtensionSettings()
+        .then((updatedSettings) => {
+          this.applySettingsSnapshot(updatedSettings);
+          this.refreshTransactionsMappingState();
+          this.refreshSaveHint();
+        })
+        .catch(() => {});
+    });
+  },
+  applySettingsSnapshot(settings: ExtensionSettings) {
     this.availableAccounts = Object.entries(settings.availableAccounts).map(([className, title]) => ({ className, title }));
     this.selectedAccounts = settings.selectedAccounts;
     this.notionApiKey = settings.notionApiKey;
@@ -82,8 +114,6 @@ Alpine.data('accountOptions', () => ({
     this.transactionsFieldMapping = normalizeTransactionsFieldMapping(settings.transactionsFieldMapping);
     this.balanceState.link = settings.balanceDatabaseLinkDraft;
     this.transactionsState.link = settings.transactionsDatabaseLinkDraft;
-    this.refreshTransactionsMappingState();
-    this.refreshSaveHint();
   },
   get balanceConnectButtonLabel() {
     return this.balanceState.isConnecting ? 'Connecting...' : 'Connect';
@@ -173,6 +203,12 @@ Alpine.data('accountOptions', () => ({
   get noSaveHint() {
     return !this.hasSaveHint;
   },
+  get hasAvailableAccounts() {
+    return this.availableAccounts.length > 0;
+  },
+  get noAvailableAccounts() {
+    return !this.hasAvailableAccounts;
+  },
   openAccountSyncTab() {
     this.activeSettingsTab = 'account';
   },
@@ -184,11 +220,9 @@ Alpine.data('accountOptions', () => ({
       const selectedAccounts = [...this.selectedAccounts];
 
       this.selectedAccounts = selectedAccounts;
-      await chrome.storage.local.set({
+      await saveExtensionSettings({
         selectedAccounts,
       });
-      const stored = await chrome.storage.local.get(['selectedAccounts']);
-      this.selectedAccounts = stored.selectedAccounts ?? [];
     } catch { /* empty */ }
   },
   onApiInput(event: Event) {

--- a/src/options/index.ts
+++ b/src/options/index.ts
@@ -25,6 +25,7 @@ const emptyTransactionsFieldMapping = (): TransactionsFieldMapping => ({
   amountProperty: '',
   merchantProperty: '',
   accountNameProperty: '',
+  typeProperty: '',
 });
 
 const normalizeTransactionsFieldMapping = (mapping: TransactionsFieldMapping | null | undefined): TransactionsFieldMapping => ({
@@ -32,6 +33,7 @@ const normalizeTransactionsFieldMapping = (mapping: TransactionsFieldMapping | n
   amountProperty: mapping?.amountProperty ?? '',
   merchantProperty: mapping?.merchantProperty ?? '',
   accountNameProperty: mapping?.accountNameProperty ?? '',
+  typeProperty: mapping?.typeProperty ?? '',
 });
 
 const markSelectedOptions = (properties: DatabaseProperty[], selectedName: string): MappingOption[] =>
@@ -65,11 +67,13 @@ Alpine.data('accountOptions', () => ({
     'number -> Amount',
     'date -> Date',
     'rich_text -> Account Name',
+    'select -> Type',
   ],
   transactionsDateOptions: [] as MappingOption[],
   transactionsAmountOptions: [] as MappingOption[],
   transactionsMerchantOptions: [] as MappingOption[],
   transactionsAccountNameOptions: [] as MappingOption[],
+  transactionsTypeOptions: [] as MappingOption[],
   saveHintText: '',
   async init() {
     const settings = await getExtensionSettings();
@@ -264,6 +268,10 @@ Alpine.data('accountOptions', () => ({
       getCompatibleProperties(this.transactionsDatabase, ['rich_text']),
       this.transactionsFieldMapping.accountNameProperty,
     );
+    this.transactionsTypeOptions = markSelectedOptions(
+      getCompatibleProperties(this.transactionsDatabase, ['select']),
+      this.transactionsFieldMapping.typeProperty,
+    );
     this.transactionsMappingErrors = validateTransactionsFieldMapping(
       this.transactionsDatabase ? this.transactionsFieldMapping : null,
       this.transactionsDatabase,
@@ -373,6 +381,7 @@ Alpine.data('accountOptions', () => ({
     this.transactionsAmountOptions = [];
     this.transactionsMerchantOptions = [];
     this.transactionsAccountNameOptions = [];
+    this.transactionsTypeOptions = [];
     this.transactionsMappingErrors = [];
     saveExtensionSettings({
       transactionsDatabase: null,
@@ -411,6 +420,15 @@ Alpine.data('accountOptions', () => ({
   onTransactionsAccountNameChange(event: Event) {
     const target = event.target as HTMLSelectElement;
     this.transactionsFieldMapping.accountNameProperty = target.value;
+    this.refreshTransactionsMappingState();
+    this.refreshSaveHint();
+    saveExtensionSettings({
+      transactionsFieldMapping: Alpine.raw(this.transactionsFieldMapping),
+    }).catch(() => {});
+  },
+  onTransactionsTypeChange(event: Event) {
+    const target = event.target as HTMLSelectElement;
+    this.transactionsFieldMapping.typeProperty = target.value;
     this.refreshTransactionsMappingState();
     this.refreshSaveHint();
     saveExtensionSettings({

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -5,16 +5,16 @@
     <title>Money Sync Popup</title>
   </head>
 
-  <body class="min-h-[360px] min-w-[460px] bg-stone-100 p-4" x-data="popup">
-    <div class="rounded-3xl bg-white p-4 shadow-lg">
+  <body class="h-[560px] w-[460px] overflow-hidden bg-white p-0" x-data="popup">
+    <div class="flex h-full flex-col bg-white p-2.5">
       <div class="flex items-center gap-3">
         <div class="flex-1">
-          <h1 class="text-2xl font-extrabold tracking-tight text-lime-800">msn</h1>
-          <p class="text-sm text-stone-500">Money Sync to Notion</p>
+          <h1 class="text-xl font-extrabold tracking-tight text-lime-800">msn</h1>
+          <p class="text-xs text-stone-500">Money Sync to Notion</p>
         </div>
         <button
           @click="onOpenSettings"
-          class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-lime-800 text-lime-800 transition hover:bg-lime-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-lime-700/30"
+          class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-lime-800 text-lime-800 transition hover:bg-lime-800 hover:text-white focus:outline-none focus:ring-2 focus:ring-lime-700/30"
         >
           <svg class="h-5 w-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13v-2a1 1 0 0 0-1-1h-.757l-.707-1.707.535-.536a1 1 0 0 0 0-1.414l-1.414-1.414a1 1 0 0 0-1.414 0l-.536.535L14 4.757V4a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v.757l-1.707.707-.536-.535a1 1 0 0 0-1.414 0L4.929 6.343a1 1 0 0 0 0 1.414l.536.536L4.757 10H4a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h.757l.707 1.707-.535.536a1 1 0 0 0 0 1.414l1.414 1.414a1 1 0 0 0 1.414 0l.536-.535 1.707.707V20a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-.757l1.707-.708.536.536a1 1 0 0 0 1.414 0l1.414-1.414a1 1 0 0 0 0-1.414l-.535-.536.707-1.707H20a1 1 0 0 0 1-1Z"/>
@@ -25,7 +25,7 @@
 
       <div
         id="amount"
-        class="mt-4 space-y-4"
+        class="mt-3 flex min-h-0 flex-1 flex-col gap-3"
         @on-error.window="errorHandling"
         @after-accounts-update.window="afterAccountsUpdate"
         @after-transactions-update.window="afterTransactionsUpdate"
@@ -36,7 +36,7 @@
         </template>
 
         <template x-if="syncResultMessage">
-          <div class="rounded-2xl border border-emerald-200 bg-emerald-50 px-3 py-3 text-emerald-800 shadow-sm">
+          <div class="rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-emerald-800">
             <div class="flex items-start gap-3">
               <span class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-white">
                 <svg class="h-4 w-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16">
@@ -51,79 +51,116 @@
           </div>
         </template>
 
-        <div class="rounded-2xl bg-stone-50 px-3 py-2 text-stone-700">
-          <p class="text-xs uppercase tracking-[0.18em] text-stone-500">Detected Page</p>
-          <p class="text-sm font-semibold" x-text="pageModeText"></p>
-        </div>
-
         <p x-show="isLoading" x-transition class="text-center text-sm text-stone-500">Loading page data...</p>
 
-        <section x-show="showingBalances" class="space-y-3">
-          <div class="rounded-2xl bg-stone-900 px-3 py-2 text-stone-50">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <p class="text-xs uppercase tracking-[0.18em] text-stone-400">Balance Database</p>
-                <p class="text-sm font-semibold" x-text="balanceDatabaseTitle"></p>
-              </div>
-              <span class="rounded-full bg-white/10 px-2.5 py-1 text-xs font-semibold" x-text="balanceStatusText"></span>
+        <section x-show="showingBalances" class="flex min-h-0 flex-1 flex-col gap-2.5">
+          <div class="flex items-center justify-between gap-3 border-b border-stone-200 px-1 pb-2 text-stone-800">
+            <div class="min-w-0">
+              <p class="text-xs uppercase tracking-[0.18em] text-stone-500">Balances Page</p>
+              <p class="truncate text-sm font-semibold">
+                <span x-text="balanceDatabaseTitle"></span>
+              </p>
             </div>
+            <span class="shrink-0 text-xs font-semibold text-stone-500" x-text="balanceStatusText"></span>
           </div>
 
-          <ul class="space-y-2">
-            <template x-for="account in filteredAccts" :key="account.name">
-              <li class="rounded-2xl bg-stone-50 px-3 py-2 shadow-sm">
-                <div class="flex items-center justify-between gap-3">
-                  <span class="font-semibold text-stone-800" x-text="account.name"></span>
-                  <span class="text-stone-500" x-text="account.balance"></span>
-                </div>
-              </li>
-            </template>
-          </ul>
+          <div class="px-1">
+            <p class="text-sm font-semibold text-stone-800" x-text="selectedBalanceCountText"></p>
+            <p class="mt-0.5 text-xs text-stone-500">Detected accounts on the current page. Choose which balances to sync.</p>
+          </div>
+
+          <div class="min-h-0 flex-1 overflow-y-auto rounded-xl border border-stone-200 bg-stone-50">
+            <ul class="divide-y divide-stone-200">
+              <template x-for="account in balanceAccountOptions" :key="account.key">
+                <li class="px-3 py-2.5">
+                  <label class="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      x-model="selectedAccounts"
+                      :value="account.key"
+                      @change="onBalanceSelectionChange"
+                      class="h-4 w-4 rounded-sm border border-stone-300 accent-lime-700 focus:ring-2 focus:ring-lime-600"
+                    />
+                    <div class="min-w-0 flex-1">
+                      <p class="truncate text-sm font-semibold text-stone-800" x-text="account.name"></p>
+                      <p class="text-[11px] text-stone-500" x-show="account.isSelected">Selected for sync</p>
+                    </div>
+                    <span class="shrink-0 text-sm text-stone-500" x-text="account.balance"></span>
+                  </label>
+                </li>
+              </template>
+            </ul>
+          </div>
 
           <button
             @click="onSync"
             :disabled="syncDisabled"
             x-text="syncBtnText"
-            class="btn-primary w-full py-3 text-base disabled:cursor-not-allowed disabled:bg-stone-400"
+            class="btn-primary w-full py-2.5 text-sm disabled:cursor-not-allowed disabled:bg-stone-400"
           ></button>
         </section>
 
-        <section x-show="showingTransactions" class="space-y-3">
-          <div class="rounded-2xl bg-stone-200 px-3 py-2 text-stone-800">
-            <div class="flex items-center justify-between gap-3">
-              <div>
-                <p class="text-xs uppercase tracking-[0.18em] text-stone-500">Transactions Database</p>
-                <p class="text-sm font-semibold" x-text="transactionsDatabaseTitle"></p>
-              </div>
-              <span class="rounded-full bg-white px-2.5 py-1 text-xs font-semibold" x-text="transactionsStatusText"></span>
+        <section x-show="showingTransactions" class="flex min-h-0 flex-1 flex-col gap-2.5">
+          <div class="flex items-center justify-between gap-3 border-b border-stone-200 px-1 pb-2 text-stone-800">
+            <div class="min-w-0">
+              <p class="text-xs uppercase tracking-[0.18em] text-stone-500">Transactions Page</p>
+              <p class="truncate text-sm font-semibold" x-text="transactionsDatabaseTitle"></p>
+            </div>
+            <span class="shrink-0 text-xs font-semibold text-stone-500" x-text="transactionsStatusText"></span>
+          </div>
+
+          <label class="flex items-start gap-3 px-1 pt-0.5">
+            <input
+              type="checkbox"
+              x-model="invertTransactionSigns"
+              @change="onInvertTransactionSignsChange"
+              class="mt-0.5 h-4 w-4 rounded-sm border border-stone-300 accent-lime-700 focus:ring-2 focus:ring-lime-600"
+            />
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-semibold text-stone-800">Invert Amount Signs</p>
+              <p class="mt-0.5 text-xs text-stone-500">Use this if the bank page reports income and expense signs in the opposite direction.</p>
+            </div>
+          </label>
+
+          <div class="px-1">
+            <p class="text-sm font-semibold text-stone-800">
+              <span x-text="transactionsPreviewCountText"></span>
+              <span class="font-normal text-stone-500">•</span>
+              <span class="font-normal text-stone-500" x-text="detectedTransactionsAccountTypeText"></span>
+            </p>
+          </div>
+
+          <div class="min-h-0 flex-1 rounded-xl border border-stone-200 bg-stone-50">
+            <div class="h-full overflow-y-auto">
+              <ul class="divide-y divide-stone-200">
+                <template x-for="transaction in transactionsPreview" :key="transaction.key">
+                  <li class="px-3 py-2.5">
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0 flex-1">
+                        <p class="truncate text-sm font-semibold text-stone-800" x-text="transaction.merchant"></p>
+                        <p class="mt-0.5 truncate text-xs text-stone-500" x-text="transaction.accountName"></p>
+                        <p class="text-[11px] text-stone-500">
+                          <span x-text="transaction.accountTypeLabel"></span>
+                          <span> • </span>
+                          <span x-text="transaction.date"></span>
+                        </p>
+                      </div>
+                      <div class="shrink-0 text-right">
+                        <p class="text-sm font-medium text-stone-700" x-text="transaction.previewAmountText"></p>
+                        <p class="text-[11px] text-stone-500" x-text="transaction.previewDirectionText"></p>
+                      </div>
+                    </div>
+                  </li>
+                </template>
+              </ul>
             </div>
           </div>
-
-          <div class="rounded-2xl bg-stone-50 px-3 py-2 shadow-sm">
-            <p class="text-sm font-semibold text-stone-800" x-text="transactionsPreviewCountText"></p>
-            <p class="text-xs text-stone-500">Using rows from the `PAST TRANSACTIONS` table.</p>
-          </div>
-
-          <ul class="space-y-2">
-            <template x-for="transaction in transactionsPreview" :key="transaction.key">
-              <li class="rounded-2xl bg-stone-50 px-3 py-2 shadow-sm">
-                <div class="flex items-start justify-between gap-3">
-                  <div class="min-w-0 flex-1">
-                    <p class="break-words text-sm font-semibold text-stone-800" x-text="transaction.merchant"></p>
-                    <p class="mt-1 text-xs text-stone-500" x-text="transaction.accountName"></p>
-                    <p class="text-xs text-stone-500" x-text="transaction.date"></p>
-                  </div>
-                  <span class="shrink-0 text-sm text-stone-600" x-text="transaction.amountText"></span>
-                </div>
-              </li>
-            </template>
-          </ul>
 
           <button
             @click="onSync"
             :disabled="syncDisabled"
             x-text="syncBtnText"
-            class="btn-primary w-full py-3 text-base disabled:cursor-not-allowed disabled:bg-stone-400"
+            class="btn-primary w-full py-2.5 text-sm disabled:cursor-not-allowed disabled:bg-stone-400"
           ></button>
         </section>
 

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -109,19 +109,6 @@
             <span class="shrink-0 text-xs font-semibold text-stone-500" x-text="transactionsStatusText"></span>
           </div>
 
-          <label class="flex items-start gap-3 px-1 pt-0.5">
-            <input
-              type="checkbox"
-              x-model="invertTransactionSigns"
-              @change="onInvertTransactionSignsChange"
-              class="mt-0.5 h-4 w-4 rounded-sm border border-stone-300 accent-lime-700 focus:ring-2 focus:ring-lime-600"
-            />
-            <div class="min-w-0 flex-1">
-              <p class="text-sm font-semibold text-stone-800">Invert Amount Signs</p>
-              <p class="mt-0.5 text-xs text-stone-500">Use this if the bank page reports income and expense signs in the opposite direction.</p>
-            </div>
-          </label>
-
           <div class="px-1">
             <p class="text-sm font-semibold text-stone-800">
               <span x-text="transactionsPreviewCountText"></span>
@@ -147,7 +134,7 @@
                       </div>
                       <div class="shrink-0 text-right">
                         <p class="text-sm font-medium text-stone-700" x-text="transaction.previewAmountText"></p>
-                        <p class="text-[11px] text-stone-500" x-text="transaction.previewDirectionText"></p>
+                        <p class="text-[11px] text-stone-500" x-text="transaction.previewTypeText"></p>
                       </div>
                     </div>
                   </li>
@@ -166,7 +153,7 @@
 
         <section x-show="showUnsupportedPage" class="space-y-3">
           <p class="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-700">
-            Open either the balances overview page or a credit card transactions page.
+            Open either the balances overview page or a supported transactions page.
           </p>
         </section>
       </div>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -49,6 +49,57 @@ const createTransactionSyncId = async (transaction: Transaction): Promise<string
 
   return sha256Hex(seed);
 };
+const getTransactionAccountTypeLabel = (accountType: TransactionAccountType): string => {
+  switch (accountType) {
+    case 'credit_card':
+      return 'Credit card';
+    case 'checking':
+      return 'Checking';
+    case 'savings':
+      return 'Savings';
+    default:
+      return 'Unknown';
+  }
+};
+const getTransactionCurrencyCode = (transaction: Transaction): string | null => {
+  const currencyMatch = transaction.amountText.match(/\b([A-Z]{3})\b/);
+  return currencyMatch?.[1] ?? null;
+};
+const getDefaultTransactionAmount = (transaction: Transaction): number => {
+  const magnitude = Math.abs(transaction.amountValue);
+
+  if (transaction.direction === 'debit') {
+    return -magnitude;
+  }
+
+  if (transaction.direction === 'credit') {
+    return magnitude;
+  }
+
+  if (transaction.accountType === 'credit_card') {
+    return transaction.amountValue > 0 ? -magnitude : magnitude;
+  }
+
+  return transaction.amountValue < 0 ? -magnitude : magnitude;
+};
+const getEffectiveTransactionAmount = (transaction: Transaction, invertTransactionSigns: boolean): number => {
+  const defaultAmount = getDefaultTransactionAmount(transaction);
+  return invertTransactionSigns ? defaultAmount * -1 : defaultAmount;
+};
+const formatTransactionAmount = (transaction: Transaction, invertTransactionSigns: boolean): string => {
+  const amount = getEffectiveTransactionAmount(transaction, invertTransactionSigns);
+  const currencyCode = getTransactionCurrencyCode(transaction);
+  const formatter = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const absAmount = formatter.format(Math.abs(amount));
+  const signPrefix = amount < 0 ? '- ' : '';
+  const currencyPrefix = currencyCode === 'USD' ? 'US$' : '$';
+  const currencySuffix = currencyCode ? ` ${currencyCode}` : '';
+
+  return `${signPrefix}${currencyPrefix}${absAmount}${currencySuffix}`;
+};
 type NotionTextFragment = {
   plain_text?: string;
 };
@@ -65,6 +116,28 @@ type NotionQueryPage = {
 
 type NotionPageCreateRequest = Parameters<Client['pages']['create']>[0];
 type NotionPageCreateProperties = NonNullable<NotionPageCreateRequest['properties']>;
+type BalanceAccountsUpdateDetail = {
+  accounts: Account[];
+  selectedAccountKeys: string[];
+};
+
+const getAccountSelectionKey = (account: Account): string => account.key?.trim() || account.name;
+const buildAvailableAccountsMap = (accounts: Account[]): Record<string, string> => {
+  const nameCounts = accounts.reduce<Record<string, number>>((result, account) => {
+    result[account.name] = (result[account.name] ?? 0) + 1;
+    return result;
+  }, {});
+
+  return Object.fromEntries(
+    accounts.map((account) => {
+      const isDuplicateName = (nameCounts[account.name] ?? 0) > 1;
+      const title = isDuplicateName ? `${account.name} (${account.balance})` : account.name;
+      return [getAccountSelectionKey(account), title];
+    }),
+  );
+};
+const matchesStoredAccountSelection = (account: Account, selectedAccounts: string[]): boolean =>
+  selectedAccounts.includes(getAccountSelectionKey(account)) || selectedAccounts.includes(account.name);
 
 const getTransactionsDateRange = (transactions: Transaction[]): { start: string; end: string } | null => {
   const dates = transactions
@@ -136,7 +209,9 @@ const getExistingTransactionSyncIds = async (
 
 Alpine.data('popup', () => ({
   filteredAccts: [] as Account[],
+  selectedAccounts: [] as string[],
   detectedTransactions: [] as Transaction[],
+  invertTransactionSigns: false,
   isLoading: false,
   error: '',
   syncResultMessage: '',
@@ -153,6 +228,25 @@ Alpine.data('popup', () => ({
     this.balanceDatabase = settings.balanceDatabase;
     this.transactionsDatabase = settings.transactionsDatabase;
     this.transactionsFieldMapping = settings.transactionsFieldMapping;
+    this.invertTransactionSigns = settings.invertTransactionSigns;
+    this.selectedAccounts = settings.selectedAccounts;
+
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+      if (areaName !== 'local') {
+        return;
+      }
+
+      if (!changes.selectedAccounts && !changes.availableAccounts && !changes.invertTransactionSigns) {
+        return;
+      }
+
+      getExtensionSettings()
+        .then((updatedSettings) => {
+          this.selectedAccounts = updatedSettings.selectedAccounts;
+          this.invertTransactionSigns = updatedSettings.invertTransactionSigns;
+        })
+        .catch(() => {});
+    });
   },
   get syncBtnText() {
     if (this.isLoading) {
@@ -186,7 +280,13 @@ Alpine.data('popup', () => ({
     return this.transactionsDatabase.schemaStatus?.isValid ? 'Ready' : 'Needs attention';
   },
   get canSyncBalanceState() {
-    return Boolean(this.balanceDatabase && this.notionApiKey && this.balanceDatabase.schemaStatus?.isValid && !this.isLoading && this.filteredAccts.length > 0);
+    return Boolean(
+      this.balanceDatabase &&
+        this.notionApiKey &&
+        this.balanceDatabase.schemaStatus?.isValid &&
+        !this.isLoading &&
+        this.selectedBalanceAccounts.length > 0,
+    );
   },
   get canSyncTransactionsState() {
     if (!this.transactionsDatabase || !this.notionApiKey || !this.transactionsDatabase.schemaStatus?.isValid || this.isLoading) {
@@ -208,6 +308,20 @@ Alpine.data('popup', () => ({
   get balanceDatabaseTitle() {
     return this.balanceDatabase ? this.balanceDatabase.title : 'Not connected';
   },
+  get balanceAccountOptions() {
+    return this.filteredAccts.map((account: Account) => ({
+      ...account,
+      key: getAccountSelectionKey(account),
+      isSelected: this.selectedAccounts.includes(getAccountSelectionKey(account)),
+    }));
+  },
+  get selectedBalanceAccounts() {
+    const selectedAccountSet = new Set(this.selectedAccounts);
+    return this.filteredAccts.filter((account: Account) => selectedAccountSet.has(getAccountSelectionKey(account)));
+  },
+  get selectedBalanceCountText() {
+    return `${this.selectedBalanceAccounts.length} of ${this.filteredAccts.length} account${this.filteredAccts.length === 1 ? '' : 's'} selected`;
+  },
   get transactionsDatabaseTitle() {
     return this.transactionsDatabase ? this.transactionsDatabase.title : 'Not connected';
   },
@@ -215,10 +329,29 @@ Alpine.data('popup', () => ({
     return this.detectedTransactions.length > 0;
   },
   get transactionsPreview() {
-    return this.detectedTransactions.slice(0, 3);
+    return this.detectedTransactions.map((transaction: Transaction) => ({
+      ...transaction,
+      previewAmountText: formatTransactionAmount(transaction, this.invertTransactionSigns),
+      previewDirectionText: getEffectiveTransactionAmount(transaction, this.invertTransactionSigns) < 0 ? 'Expense' : 'Income',
+      accountTypeLabel: getTransactionAccountTypeLabel(transaction.accountType),
+    }));
   },
   get transactionsPreviewCountText() {
     return `${this.detectedTransactions.length} transaction${this.detectedTransactions.length === 1 ? '' : 's'} detected`;
+  },
+  get detectedTransactionsAccountTypeText() {
+    if (this.detectedTransactions.length === 0) {
+      return 'Unknown';
+    }
+
+    const uniqueAccountTypes = Array.from(
+      new Set<TransactionAccountType>(this.detectedTransactions.map((transaction: Transaction) => transaction.accountType)),
+    );
+    if (uniqueAccountTypes.length === 1) {
+      return getTransactionAccountTypeLabel(uniqueAccountTypes[0] ?? 'unknown');
+    }
+
+    return uniqueAccountTypes.map((accountType: TransactionAccountType) => getTransactionAccountTypeLabel(accountType)).join(', ');
   },
   get showingBalances() {
     return this.pageMode === 'balances';
@@ -261,11 +394,12 @@ Alpine.data('popup', () => ({
     this.error = '';
     this.syncResultMessage = '';
   },
-  afterAccountsUpdate(event: CustomEvent<Account[]>) {
+  afterAccountsUpdate(event: CustomEvent<BalanceAccountsUpdateDetail>) {
     this.isLoading = false;
     this.pageMode = 'balances';
     if (event.detail) {
-      this.filteredAccts = event.detail;
+      this.filteredAccts = event.detail.accounts;
+      this.selectedAccounts = event.detail.selectedAccountKeys;
       this.detectedTransactions = [];
     }
   },
@@ -282,6 +416,22 @@ Alpine.data('popup', () => ({
     this.error = '';
     this.syncResultMessage = '';
     chrome.runtime.openOptionsPage();
+  },
+  async onInvertTransactionSignsChange() {
+    await saveExtensionSettings({
+      invertTransactionSigns: this.invertTransactionSigns,
+    });
+  },
+  async onBalanceSelectionChange() {
+    const selectedAccounts = this.filteredAccts
+      .map((account: Account) => getAccountSelectionKey(account))
+      .filter((accountKey: string) => this.selectedAccounts.includes(accountKey));
+
+    this.selectedAccounts = selectedAccounts;
+    await saveExtensionSettings({
+      availableAccounts: buildAvailableAccountsMap(this.filteredAccts),
+      selectedAccounts,
+    });
   },
   async onSync() {
     if (this.showingTransactions) {
@@ -329,7 +479,7 @@ Alpine.data('popup', () => ({
       }
 
       await Promise.all(
-        this.filteredAccts.map((acct: Account) =>
+        this.selectedBalanceAccounts.map((acct: Account) =>
           notion.pages.create({
             parent: {
               data_source_id: balanceDatabase.dataSourceId!,
@@ -361,7 +511,7 @@ Alpine.data('popup', () => ({
         ),
       );
       this.syncBtnTitle = 'Synced';
-      this.syncResultMessage = `Created ${this.filteredAccts.length} balance item${this.filteredAccts.length === 1 ? '' : 's'}.`;
+      this.syncResultMessage = `Created ${this.selectedBalanceAccounts.length} balance item${this.selectedBalanceAccounts.length === 1 ? '' : 's'}.`;
       window.dispatchEvent(new CustomEvent('after-accounts-update', {}));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -477,7 +627,7 @@ Alpine.data('popup', () => ({
             },
             [this.transactionsFieldMapping!.amountProperty]: {
               type: 'number',
-              number: transaction.amountValue,
+              number: getEffectiveTransactionAmount(transaction, this.invertTransactionSigns),
             },
             [this.transactionsFieldMapping!.accountNameProperty]: toRichText(transaction.accountName),
             [TRANSACTION_SYNC_ID_PROPERTY]: toRichText(syncId),
@@ -608,15 +758,15 @@ const scanCurrentPage = () => {
               return;
             }
 
-            chrome.storage.local.set({ availableAccounts });
             const settings = await getExtensionSettings();
-            const selectedAccounts = settings.selectedAccounts.length ? settings.selectedAccounts : Object.keys(availableAccounts);
+            const allGroupKeys = Object.keys(availableAccounts);
+            const legacySelectedGroupKeys = allGroupKeys.filter((groupKey) => settings.selectedAccounts.includes(groupKey));
 
             chrome.scripting.executeScript(
               {
                 target: { tabId: currentTab.id! },
                 func: bankAdapter.extractAccounts,
-                args: [selectedAccounts],
+                args: [allGroupKeys],
               },
               (accountResults) => {
                 isScanningCurrentPage = false;
@@ -625,11 +775,78 @@ const scanCurrentPage = () => {
                   return;
                 }
 
-                const accounts = accountResults?.[0]?.result as Account[];
-                window.dispatchEvent(
-                  new CustomEvent('after-accounts-update', {
-                    detail: accounts,
-                  }),
+                const accounts = (accountResults?.[0]?.result ?? []) as Account[];
+                if (accounts.length === 0) {
+                  dispatchScanError(`Error: unable to find any ${bankAdapter.name} accounts on the current balances page.`);
+                  return;
+                }
+
+                const accountKeys = accounts.map((account) => getAccountSelectionKey(account));
+                const matchedSelectedAccountKeys = accounts
+                  .filter((account) => matchesStoredAccountSelection(account, settings.selectedAccounts))
+                  .map((account) => getAccountSelectionKey(account));
+                const shouldDefaultToAllAccounts =
+                  settings.selectedAccounts.length === 0
+                    ? Object.keys(settings.availableAccounts).length === 0
+                    : matchedSelectedAccountKeys.length === 0 && legacySelectedGroupKeys.length === 0;
+
+                const finalizeAccountSelection = async (selectedAccountKeys: string[]) => {
+                  const normalizedSelectedAccountKeys = accountKeys.filter((accountKey) => selectedAccountKeys.includes(accountKey));
+
+                  await saveExtensionSettings({
+                    availableAccounts: buildAvailableAccountsMap(accounts),
+                    selectedAccounts: normalizedSelectedAccountKeys,
+                  });
+
+                  window.dispatchEvent(
+                    new CustomEvent<BalanceAccountsUpdateDetail>('after-accounts-update', {
+                      detail: {
+                        accounts,
+                        selectedAccountKeys: normalizedSelectedAccountKeys,
+                      },
+                    }),
+                  );
+                };
+
+                if (matchedSelectedAccountKeys.length > 0) {
+                  finalizeAccountSelection(matchedSelectedAccountKeys).catch((error) => {
+                    const message = error instanceof Error ? error.message : String(error);
+                    dispatchScanError(`Error: ${message}`);
+                  });
+                  return;
+                }
+
+                if (legacySelectedGroupKeys.length === 0) {
+                  const defaultSelectedAccountKeys = shouldDefaultToAllAccounts ? accountKeys : [];
+                  finalizeAccountSelection(defaultSelectedAccountKeys).catch((error) => {
+                    const message = error instanceof Error ? error.message : String(error);
+                    dispatchScanError(`Error: ${message}`);
+                  });
+                  return;
+                }
+
+                chrome.scripting.executeScript(
+                  {
+                    target: { tabId: currentTab.id! },
+                    func: bankAdapter.extractAccounts,
+                    args: [legacySelectedGroupKeys],
+                  },
+                  (legacyAccountResults) => {
+                    if (chrome.runtime.lastError) {
+                      dispatchScanError(`Error: ${chrome.runtime.lastError.message}`);
+                      return;
+                    }
+
+                    const legacyAccounts = (legacyAccountResults?.[0]?.result ?? []) as Account[];
+                    const legacySelectedAccountKeys = accountKeys.filter((accountKey) =>
+                      legacyAccounts.some((account) => getAccountSelectionKey(account) === accountKey || account.name === accountKey),
+                    );
+
+                    finalizeAccountSelection(legacySelectedAccountKeys.length > 0 ? legacySelectedAccountKeys : accountKeys).catch((error) => {
+                      const message = error instanceof Error ? error.message : String(error);
+                      dispatchScanError(`Error: ${message}`);
+                    });
+                  },
                 );
               },
             );

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -3,7 +3,13 @@ import { Client } from '@notionhq/client';
 
 import '../global.css';
 import { detectBankFromHost } from '../lib/bank';
-import { createNotionClient, refreshNotionDatabaseConnection, TRANSACTION_SYNC_ID_PROPERTY, validateTransactionsFieldMapping } from '../lib/notion';
+import {
+  createNotionClient,
+  refreshNotionDatabaseConnection,
+  suggestTransactionsFieldMapping,
+  TRANSACTION_SYNC_ID_PROPERTY,
+  validateTransactionsFieldMapping,
+} from '../lib/notion';
 import { getExtensionSettings, saveExtensionSettings } from '../lib/storage';
 
 window.Alpine = Alpine;
@@ -43,7 +49,7 @@ const createTransactionSyncId = async (transaction: Transaction): Promise<string
   const seed = [
     normalizeSyncIdPart(transaction.merchant),
     transaction.date,
-    transaction.amountValue.toFixed(2),
+    transaction.rawAmountValue.toFixed(2),
     normalizeSyncIdPart(transaction.accountName),
   ].join('|');
 
@@ -62,43 +68,26 @@ const getTransactionAccountTypeLabel = (accountType: TransactionAccountType): st
   }
 };
 const getTransactionCurrencyCode = (transaction: Transaction): string | null => {
+  if (transaction.currencyCode) {
+    return transaction.currencyCode;
+  }
+
   const currencyMatch = transaction.amountText.match(/\b([A-Z]{3})\b/);
   return currencyMatch?.[1] ?? null;
 };
-const getDefaultTransactionAmount = (transaction: Transaction): number => {
-  const magnitude = Math.abs(transaction.amountValue);
-
-  if (transaction.direction === 'debit') {
-    return -magnitude;
-  }
-
-  if (transaction.direction === 'credit') {
-    return magnitude;
-  }
-
-  if (transaction.accountType === 'credit_card') {
-    return transaction.amountValue > 0 ? -magnitude : magnitude;
-  }
-
-  return transaction.amountValue < 0 ? -magnitude : magnitude;
-};
-const getEffectiveTransactionAmount = (transaction: Transaction, invertTransactionSigns: boolean): number => {
-  const defaultAmount = getDefaultTransactionAmount(transaction);
-  return invertTransactionSigns ? defaultAmount * -1 : defaultAmount;
-};
-const formatTransactionAmount = (transaction: Transaction, invertTransactionSigns: boolean): string => {
-  const amount = getEffectiveTransactionAmount(transaction, invertTransactionSigns);
+const getTransactionTypeLabel = (type: TransactionType): string => (type === 'debit' ? 'Debit' : 'Credit');
+const formatTransactionAmount = (transaction: Transaction): string => {
+  const amount = Math.abs(transaction.amountValue);
   const currencyCode = getTransactionCurrencyCode(transaction);
   const formatter = new Intl.NumberFormat(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
-  const absAmount = formatter.format(Math.abs(amount));
-  const signPrefix = amount < 0 ? '- ' : '';
+  const absAmount = formatter.format(amount);
   const currencyPrefix = currencyCode === 'USD' ? 'US$' : '$';
   const currencySuffix = currencyCode ? ` ${currencyCode}` : '';
 
-  return `${signPrefix}${currencyPrefix}${absAmount}${currencySuffix}`;
+  return `${currencyPrefix}${absAmount}${currencySuffix}`;
 };
 type NotionTextFragment = {
   plain_text?: string;
@@ -207,11 +196,25 @@ const getExistingTransactionSyncIds = async (
   return syncIds;
 };
 
+const resolveTransactionsFieldMapping = (
+  mapping: TransactionsFieldMapping | null,
+  database: Database | null,
+): TransactionsFieldMapping | null => {
+  if (!database) {
+    return mapping;
+  }
+
+  if (mapping && validateTransactionsFieldMapping(mapping, database).length === 0) {
+    return mapping;
+  }
+
+  return suggestTransactionsFieldMapping(database);
+};
+
 Alpine.data('popup', () => ({
   filteredAccts: [] as Account[],
   selectedAccounts: [] as string[],
   detectedTransactions: [] as Transaction[],
-  invertTransactionSigns: false,
   isLoading: false,
   error: '',
   syncResultMessage: '',
@@ -227,23 +230,41 @@ Alpine.data('popup', () => ({
     this.notionApiKey = settings.notionApiKey;
     this.balanceDatabase = settings.balanceDatabase;
     this.transactionsDatabase = settings.transactionsDatabase;
-    this.transactionsFieldMapping = settings.transactionsFieldMapping;
-    this.invertTransactionSigns = settings.invertTransactionSigns;
+    this.transactionsFieldMapping = resolveTransactionsFieldMapping(settings.transactionsFieldMapping, settings.transactionsDatabase);
     this.selectedAccounts = settings.selectedAccounts;
+
+    if (this.transactionsFieldMapping !== settings.transactionsFieldMapping) {
+      saveExtensionSettings({
+        transactionsFieldMapping: this.transactionsFieldMapping,
+      }).catch(() => {});
+    }
 
     chrome.storage.onChanged.addListener((changes, areaName) => {
       if (areaName !== 'local') {
         return;
       }
 
-      if (!changes.selectedAccounts && !changes.availableAccounts && !changes.invertTransactionSigns) {
+      if (
+        !changes.selectedAccounts &&
+        !changes.availableAccounts &&
+        !changes.balanceDatabase &&
+        !changes.transactionsDatabase &&
+        !changes.transactionsFieldMapping &&
+        !changes.notionApiKey
+      ) {
         return;
       }
 
       getExtensionSettings()
         .then((updatedSettings) => {
           this.selectedAccounts = updatedSettings.selectedAccounts;
-          this.invertTransactionSigns = updatedSettings.invertTransactionSigns;
+          this.notionApiKey = updatedSettings.notionApiKey;
+          this.balanceDatabase = updatedSettings.balanceDatabase;
+          this.transactionsDatabase = updatedSettings.transactionsDatabase;
+          this.transactionsFieldMapping = resolveTransactionsFieldMapping(
+            updatedSettings.transactionsFieldMapping,
+            updatedSettings.transactionsDatabase,
+          );
         })
         .catch(() => {});
     });
@@ -272,7 +293,7 @@ Alpine.data('popup', () => ({
       return 'Not connected';
     }
 
-    const mappingErrors = validateTransactionsFieldMapping(this.transactionsFieldMapping, this.transactionsDatabase);
+    const mappingErrors = validateTransactionsFieldMapping(this.resolvedTransactionsFieldMapping, this.transactionsDatabase);
     if (mappingErrors.length > 0) {
       return 'Mapping incomplete';
     }
@@ -293,7 +314,7 @@ Alpine.data('popup', () => ({
       return false;
     }
 
-    const mappingErrors = validateTransactionsFieldMapping(this.transactionsFieldMapping, this.transactionsDatabase);
+    const mappingErrors = validateTransactionsFieldMapping(this.resolvedTransactionsFieldMapping, this.transactionsDatabase);
     return mappingErrors.length === 0 && this.detectedTransactions.length > 0;
   },
   get syncDisabled() {
@@ -325,14 +346,17 @@ Alpine.data('popup', () => ({
   get transactionsDatabaseTitle() {
     return this.transactionsDatabase ? this.transactionsDatabase.title : 'Not connected';
   },
+  get resolvedTransactionsFieldMapping() {
+    return resolveTransactionsFieldMapping(this.transactionsFieldMapping, this.transactionsDatabase);
+  },
   get hasTransactionsPreview() {
     return this.detectedTransactions.length > 0;
   },
   get transactionsPreview() {
     return this.detectedTransactions.map((transaction: Transaction) => ({
       ...transaction,
-      previewAmountText: formatTransactionAmount(transaction, this.invertTransactionSigns),
-      previewDirectionText: getEffectiveTransactionAmount(transaction, this.invertTransactionSigns) < 0 ? 'Expense' : 'Income',
+      previewAmountText: formatTransactionAmount(transaction),
+      previewTypeText: getTransactionTypeLabel(transaction.type),
       accountTypeLabel: getTransactionAccountTypeLabel(transaction.accountType),
     }));
   },
@@ -416,11 +440,6 @@ Alpine.data('popup', () => ({
     this.error = '';
     this.syncResultMessage = '';
     chrome.runtime.openOptionsPage();
-  },
-  async onInvertTransactionSignsChange() {
-    await saveExtensionSettings({
-      invertTransactionSigns: this.invertTransactionSigns,
-    });
   },
   async onBalanceSelectionChange() {
     const selectedAccounts = this.filteredAccts
@@ -530,8 +549,9 @@ Alpine.data('popup', () => ({
       return;
     }
 
-    const mappingErrors = validateTransactionsFieldMapping(this.transactionsFieldMapping, this.transactionsDatabase);
-    if (mappingErrors.length > 0 || !this.transactionsFieldMapping) {
+    const initialMapping = this.resolvedTransactionsFieldMapping;
+    const mappingErrors = validateTransactionsFieldMapping(initialMapping, this.transactionsDatabase);
+    if (mappingErrors.length > 0 || !initialMapping) {
       this.error = mappingErrors[0] ?? 'Transactions field mapping is incomplete.';
       return;
     }
@@ -557,25 +577,31 @@ Alpine.data('popup', () => ({
     try {
       const transactionsDatabase = await refreshNotionDatabaseConnection(notion, this.transactionsDatabase, 'transactions');
       this.transactionsDatabase = transactionsDatabase;
+      this.transactionsFieldMapping = resolveTransactionsFieldMapping(this.transactionsFieldMapping, transactionsDatabase);
       await saveExtensionSettings({
         transactionsDatabase,
+        transactionsFieldMapping: this.transactionsFieldMapping,
       });
 
-      const refreshedMappingErrors = validateTransactionsFieldMapping(this.transactionsFieldMapping, transactionsDatabase);
+      const resolvedMapping = this.resolvedTransactionsFieldMapping;
+      const refreshedMappingErrors = validateTransactionsFieldMapping(resolvedMapping, transactionsDatabase);
       if (refreshedMappingErrors.length > 0) {
         this.error = refreshedMappingErrors[0];
         return;
       }
 
       const merchantProperty = transactionsDatabase.properties.find(
-        (property) => property.name === this.transactionsFieldMapping!.merchantProperty,
+        (property) => property.name === resolvedMapping!.merchantProperty,
+      );
+      const typeProperty = transactionsDatabase.properties.find(
+        (property) => property.name === resolvedMapping!.typeProperty,
       );
       const syncIdProperty = transactionsDatabase.properties.find(
         (property) => property.name === TRANSACTION_SYNC_ID_PROPERTY,
       );
 
-      if (!merchantProperty || !syncIdProperty) {
-        this.error = 'Transactions database is missing either the merchant field or the Sync ID field.';
+      if (!merchantProperty || !typeProperty || !syncIdProperty) {
+        this.error = 'Transactions database is missing the merchant field, type field, or Sync ID field.';
         return;
       }
 
@@ -595,7 +621,7 @@ Alpine.data('popup', () => ({
       const existingSyncIds = await getExistingTransactionSyncIds(
         notion,
         transactionsDatabase.dataSourceId!,
-        this.transactionsFieldMapping.dateProperty,
+        resolvedMapping!.dateProperty,
         transactionDateRange,
       );
 
@@ -619,22 +645,31 @@ Alpine.data('popup', () => ({
       await Promise.all(
         unsyncedTransactions.map(({ transaction, syncId }) => {
           const properties: NotionPageCreateProperties = {
-            [this.transactionsFieldMapping!.dateProperty]: {
+            [resolvedMapping!.dateProperty]: {
               type: 'date',
               date: {
                 start: transaction.date,
               },
             },
-            [this.transactionsFieldMapping!.amountProperty]: {
+            [resolvedMapping!.amountProperty]: {
               type: 'number',
-              number: getEffectiveTransactionAmount(transaction, this.invertTransactionSigns),
+              number: Math.abs(transaction.amountValue),
             },
-            [this.transactionsFieldMapping!.accountNameProperty]: toRichText(transaction.accountName),
+            [resolvedMapping!.accountNameProperty]: toRichText(transaction.accountName),
             [TRANSACTION_SYNC_ID_PROPERTY]: toRichText(syncId),
           };
 
-          properties[this.transactionsFieldMapping!.merchantProperty] =
+          properties[resolvedMapping!.merchantProperty] =
             merchantProperty.type === 'title' ? toTitle(transaction.merchant) : toRichText(transaction.merchant);
+          properties[resolvedMapping!.typeProperty] =
+            typeProperty.type === 'select'
+              ? {
+                  type: 'select',
+                  select: {
+                    name: transaction.type,
+                  },
+                }
+              : toRichText(transaction.type);
 
           return notion.pages.create({
             parent: {

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -2,7 +2,8 @@ import Alpine from '@alpinejs/csp';
 import { Client } from '@notionhq/client';
 
 import '../global.css';
-import { detectBankFromHost } from '../lib/bank';
+import { detectBankFromHost, getBankAdapterById } from '../lib/bank';
+import type { BankId } from '../lib/bank/type';
 import {
   createNotionClient,
   refreshNotionDatabaseConnection,
@@ -105,13 +106,24 @@ type NotionQueryPage = {
 
 type NotionPageCreateRequest = Parameters<Client['pages']['create']>[0];
 type NotionPageCreateProperties = NonNullable<NotionPageCreateRequest['properties']>;
+type BankAccountKey = string;
 type BalanceAccountsUpdateDetail = {
+  bankId: BankId;
   accounts: Account[];
   selectedAccountKeys: string[];
 };
+const BANK_ACCOUNT_KEY_SEPARATOR = '::';
+const toBankScopedAccountKey = (bankId: BankId, accountKey: string): BankAccountKey => `${bankId}${BANK_ACCOUNT_KEY_SEPARATOR}${accountKey}`;
+const isBankScopedAccountKey = (value: string, bankId: BankId): boolean => value.startsWith(`${bankId}${BANK_ACCOUNT_KEY_SEPARATOR}`);
+const fromBankScopedAccountKey = (value: string, bankId: BankId): string =>
+  isBankScopedAccountKey(value, bankId) ? value.slice(`${bankId}${BANK_ACCOUNT_KEY_SEPARATOR}`.length) : value;
 
 const getAccountSelectionKey = (account: Account): string => account.key?.trim() || account.name;
-const buildAvailableAccountsMap = (accounts: Account[]): Record<string, string> => {
+const getScopedAvailableAccountsForBank = (availableAccounts: Record<string, string>, bankId: BankId): Record<string, string> =>
+  Object.fromEntries(Object.entries(availableAccounts).filter(([key]) => isBankScopedAccountKey(key, bankId)));
+const getScopedSelectedAccountsForBank = (selectedAccounts: string[], bankId: BankId): string[] =>
+  selectedAccounts.filter((key) => isBankScopedAccountKey(key, bankId)).map((key) => fromBankScopedAccountKey(key, bankId));
+const buildAvailableAccountsMap = (accounts: Account[], bankId: BankId, bankLabel: string): Record<string, string> => {
   const nameCounts = accounts.reduce<Record<string, number>>((result, account) => {
     result[account.name] = (result[account.name] ?? 0) + 1;
     return result;
@@ -120,13 +132,15 @@ const buildAvailableAccountsMap = (accounts: Account[]): Record<string, string> 
   return Object.fromEntries(
     accounts.map((account) => {
       const isDuplicateName = (nameCounts[account.name] ?? 0) > 1;
-      const title = isDuplicateName ? `${account.name} (${account.balance})` : account.name;
-      return [getAccountSelectionKey(account), title];
+      const baseTitle = isDuplicateName ? `${account.name} (${account.balance})` : account.name;
+      return [toBankScopedAccountKey(bankId, getAccountSelectionKey(account)), `${bankLabel} • ${baseTitle}`];
     }),
   );
 };
-const matchesStoredAccountSelection = (account: Account, selectedAccounts: string[]): boolean =>
-  selectedAccounts.includes(getAccountSelectionKey(account)) || selectedAccounts.includes(account.name);
+const matchesStoredAccountSelection = (account: Account, selectedAccounts: string[], bankId: BankId): boolean =>
+  selectedAccounts.includes(toBankScopedAccountKey(bankId, getAccountSelectionKey(account))) ||
+  selectedAccounts.includes(getAccountSelectionKey(account)) ||
+  selectedAccounts.includes(account.name);
 
 const getTransactionsDateRange = (transactions: Transaction[]): { start: string; end: string } | null => {
   const dates = transactions
@@ -214,6 +228,7 @@ const resolveTransactionsFieldMapping = (
 Alpine.data('popup', () => ({
   filteredAccts: [] as Account[],
   selectedAccounts: [] as string[],
+  currentBankId: null as BankId | null,
   detectedTransactions: [] as Transaction[],
   isLoading: false,
   error: '',
@@ -231,7 +246,7 @@ Alpine.data('popup', () => ({
     this.balanceDatabase = settings.balanceDatabase;
     this.transactionsDatabase = settings.transactionsDatabase;
     this.transactionsFieldMapping = resolveTransactionsFieldMapping(settings.transactionsFieldMapping, settings.transactionsDatabase);
-    this.selectedAccounts = settings.selectedAccounts;
+    this.selectedAccounts = [];
 
     if (this.transactionsFieldMapping !== settings.transactionsFieldMapping) {
       saveExtensionSettings({
@@ -257,7 +272,7 @@ Alpine.data('popup', () => ({
 
       getExtensionSettings()
         .then((updatedSettings) => {
-          this.selectedAccounts = updatedSettings.selectedAccounts;
+          this.selectedAccounts = this.currentBankId ? getScopedSelectedAccountsForBank(updatedSettings.selectedAccounts, this.currentBankId) : [];
           this.notionApiKey = updatedSettings.notionApiKey;
           this.balanceDatabase = updatedSettings.balanceDatabase;
           this.transactionsDatabase = updatedSettings.transactionsDatabase;
@@ -422,6 +437,7 @@ Alpine.data('popup', () => ({
     this.isLoading = false;
     this.pageMode = 'balances';
     if (event.detail) {
+      this.currentBankId = event.detail.bankId;
       this.filteredAccts = event.detail.accounts;
       this.selectedAccounts = event.detail.selectedAccountKeys;
       this.detectedTransactions = [];
@@ -442,14 +458,35 @@ Alpine.data('popup', () => ({
     chrome.runtime.openOptionsPage();
   },
   async onBalanceSelectionChange() {
+    if (!this.currentBankId) {
+      return;
+    }
+
     const selectedAccounts = this.filteredAccts
       .map((account: Account) => getAccountSelectionKey(account))
       .filter((accountKey: string) => this.selectedAccounts.includes(accountKey));
 
+    const settings = await getExtensionSettings();
+    const currentBankScopedAccountKeys = this.filteredAccts.map((account: Account) => toBankScopedAccountKey(this.currentBankId!, getAccountSelectionKey(account)));
+    const mergedAvailableAccounts = Object.fromEntries(
+      Object.entries(settings.availableAccounts).filter(
+        ([key]) => !currentBankScopedAccountKeys.includes(key) && !this.filteredAccts.some((account: Account) => getAccountSelectionKey(account) === key),
+      ),
+    );
+    const mergedSelectedAccounts = settings.selectedAccounts.filter(
+      (key: string) =>
+        !currentBankScopedAccountKeys.includes(key) &&
+        !this.filteredAccts.some((account: Account) => getAccountSelectionKey(account) === key || account.name === key),
+    );
+    const currentBankLabel = getBankAdapterById(this.currentBankId)?.name ?? this.currentBankId.toUpperCase();
+
     this.selectedAccounts = selectedAccounts;
     await saveExtensionSettings({
-      availableAccounts: buildAvailableAccountsMap(this.filteredAccts),
-      selectedAccounts,
+      availableAccounts: {
+        ...mergedAvailableAccounts,
+        ...buildAvailableAccountsMap(this.filteredAccts, this.currentBankId, currentBankLabel),
+      },
+      selectedAccounts: [...mergedSelectedAccounts, ...selectedAccounts.map((accountKey: string) => toBankScopedAccountKey(this.currentBankId!, accountKey))],
     });
   },
   async onSync() {
@@ -794,6 +831,8 @@ const scanCurrentPage = () => {
             }
 
             const settings = await getExtensionSettings();
+            const scopedAvailableAccounts = getScopedAvailableAccountsForBank(settings.availableAccounts, bankAdapter.id);
+            const scopedSelectedAccounts = getScopedSelectedAccountsForBank(settings.selectedAccounts, bankAdapter.id);
             const allGroupKeys = Object.keys(availableAccounts);
             const legacySelectedGroupKeys = allGroupKeys.filter((groupKey) => settings.selectedAccounts.includes(groupKey));
 
@@ -818,24 +857,41 @@ const scanCurrentPage = () => {
 
                 const accountKeys = accounts.map((account) => getAccountSelectionKey(account));
                 const matchedSelectedAccountKeys = accounts
-                  .filter((account) => matchesStoredAccountSelection(account, settings.selectedAccounts))
+                  .filter((account) => matchesStoredAccountSelection(account, settings.selectedAccounts, bankAdapter.id))
                   .map((account) => getAccountSelectionKey(account));
                 const shouldDefaultToAllAccounts =
-                  settings.selectedAccounts.length === 0
-                    ? Object.keys(settings.availableAccounts).length === 0
-                    : matchedSelectedAccountKeys.length === 0 && legacySelectedGroupKeys.length === 0;
+                  scopedSelectedAccounts.length === 0 && legacySelectedGroupKeys.length === 0 && Object.keys(scopedAvailableAccounts).length === 0;
 
                 const finalizeAccountSelection = async (selectedAccountKeys: string[]) => {
                   const normalizedSelectedAccountKeys = accountKeys.filter((accountKey) => selectedAccountKeys.includes(accountKey));
+                  const scopedAccountKeys = accountKeys.map((accountKey) => toBankScopedAccountKey(bankAdapter.id, accountKey));
+                  const mergedAvailableAccounts = Object.fromEntries(
+                    Object.entries(settings.availableAccounts).filter(
+                      ([key]) => !scopedAccountKeys.includes(key) && !accountKeys.includes(key),
+                    ),
+                  );
+                  const mergedSelectedAccounts = settings.selectedAccounts.filter(
+                    (key) =>
+                      !scopedAccountKeys.includes(key) &&
+                      !accountKeys.includes(key) &&
+                      !accounts.some((account) => account.name === key),
+                  );
 
                   await saveExtensionSettings({
-                    availableAccounts: buildAvailableAccountsMap(accounts),
-                    selectedAccounts: normalizedSelectedAccountKeys,
+                    availableAccounts: {
+                      ...mergedAvailableAccounts,
+                      ...buildAvailableAccountsMap(accounts, bankAdapter.id, bankAdapter.name),
+                    },
+                    selectedAccounts: [
+                      ...mergedSelectedAccounts,
+                      ...normalizedSelectedAccountKeys.map((accountKey) => toBankScopedAccountKey(bankAdapter.id, accountKey)),
+                    ],
                   });
 
                   window.dispatchEvent(
                     new CustomEvent<BalanceAccountsUpdateDetail>('after-accounts-update', {
                       detail: {
+                        bankId: bankAdapter.id,
                         accounts,
                         selectedAccountKeys: normalizedSelectedAccountKeys,
                       },


### PR DESCRIPTION
## Summary
- add and register a Wealthsimple bank adapter scaffold alongside the existing CIBC adapter
- parse Wealthsimple balances from /app/home account cards and keep popup/settings account selection synced through local storage with backward-compatible migration from older saved selections
- parse Wealthsimple transactions for credit card, chequing, joint chequing, and savings-style pages using structural DOM cues instead of semantic class names
- keep transaction Sync ID hashing based on the banks original signed amount while adding account-type detection and an Invert Amount Signs popup option that immediately updates the preview and synced Notion amount
- compact the popup UI so account and transaction sync fit more cleanly inside Chrome popup constraints with fixed-height scrollable lists and always-visible sync actions

## Testing
- npm run build


